### PR TITLE
Add a class to start imageJ from IDE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -226,6 +226,12 @@
 			<version>${jaxb-api.version}</version>
 			<scope>test</scope>
 		</dependency>
+		<!-- include imagej-legacy at test runtime -->
+		<dependency>
+			<groupId>net.imagej</groupId>
+			<artifactId>imagej-legacy</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 
 

--- a/src/test/java/org/janelia/saalfeldlab/n5/universe/demo/StartImageJ.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/universe/demo/StartImageJ.java
@@ -1,0 +1,49 @@
+/*-
+ * #%L
+ * Mastodon
+ * %%
+ * Copyright (C) 2014 - 2024 Tobias Pietzsch, Jean-Yves Tinevez
+ * %%
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions are met:
+ * 
+ * 1. Redistributions of source code must retain the above copyright notice,
+ *    this list of conditions and the following disclaimer.
+ * 2. Redistributions in binary form must reproduce the above copyright notice,
+ *    this list of conditions and the following disclaimer in the documentation
+ *    and/or other materials provided with the distribution.
+ * 
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDERS OR CONTRIBUTORS BE
+ * LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+ * CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+ * SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+ * INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+ * CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+ * POSSIBILITY OF SUCH DAMAGE.
+ * #L%
+ */
+package org.janelia.saalfeldlab.n5.universe.demo;
+
+import org.scijava.Context;
+import org.scijava.ui.UIService;
+
+/**
+ * Shows the ImageJ main window
+ *
+ * @author Stefan Hahmann
+ */
+public class StartImageJ
+{
+
+	public static void main( final String... args )
+	{
+		@SuppressWarnings( "resource" )
+		final Context context = new Context();
+		final UIService uiService = context.service( UIService.class );
+		uiService.showUI();
+	}
+}


### PR DESCRIPTION
This PR adds a new class StartImageJ

* This class may be used to start ImageJ with N5 plugins installed from IDE
* For this purpose, it adds imagej-legacy as a test dependency