### PR TITLE
fix: ensure AmazonS3 has a connection to an S3 server before getting KVA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
 
-		<n5.version>3.4.1</n5.version>
+		<n5.version>3.4.2-SNAPSHOT</n5.version>
 		<n5-ij.version>4.3.0</n5-ij.version>
 		<n5-aws-s3.version>4.2.2</n5-aws-s3.version>
 		<n5-google-cloud.version>5.0.0</n5-google-cloud.version>


### PR DESCRIPTION
it was possible to get an AmazonS3 instance and provide it to a KVA without checking that it was valid. We are not more strict about that. It allows fewer false positives when the KVA should be HTTP, instead of S3