### PR TITLE
Opening of OME Zarr v0.5 datasets due to inconsistency of axes ordering

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/universe/metadata/MetadataUtils.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/universe/metadata/MetadataUtils.java
@@ -520,4 +520,19 @@ public class MetadataUtils {
 
 	}
 
+	/**
+	 * Creates a new array containing all elements of the input array in reversed order.
+	 *
+	 * @param <T> the type of elements in the array
+	 * @param array the input array to be reversed
+	 * @return a new array with elements in reversed order compared to the input array
+	 */
+	public static < T > T[] reversedCopy( T[] array )
+	{
+		T[] result = array.clone();
+		for ( int i = 0, j = array.length - 1; i < array.length; i++, j-- )
+			result[ i ] = array[ j ];
+		return result;
+	}
+
 }

--- a/src/main/java/org/janelia/saalfeldlab/n5/universe/metadata/ome/ngff/v05/MultiscalesAdapter.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/universe/metadata/ome/ngff/v05/MultiscalesAdapter.java
@@ -27,14 +27,15 @@ public class MultiscalesAdapter implements JsonDeserializer<OmeNgffMultiScaleMet
 		final String type = MetadataUtils.getStringNullable(jobj.get("type"));
 		final String version = "0.5";
 
-		final Axis[] axes = context.deserialize(jobj.get("axes"), Axis[].class);
+		final Axis[] axes = context.deserialize( jobj.get( "axes" ), Axis[].class );
+		final Axis[] axesInReverseOrder = MetadataUtils.reversedCopy( axes );
 		final OmeNgffDataset[] datasets = context.deserialize(jobj.get("datasets"), OmeNgffDataset[].class);
 		final CoordinateTransformation<?>[] coordinateTransformations = context
 				.deserialize(jobj.get("coordinateTransformations"), CoordinateTransformation[].class);
 		final OmeNgffDownsamplingMetadata metadata = context.deserialize(jobj.get("metadata"),
 				OmeNgffDownsamplingMetadata.class);
 
-		return new OmeNgffMultiScaleMetadata(axes.length, "", name, type, version, axes, datasets, null,
+		return new OmeNgffMultiScaleMetadata( axesInReverseOrder.length, "", name, type, version, axesInReverseOrder, datasets, null,
 				coordinateTransformations, metadata, false);
 	}
 
@@ -62,5 +63,4 @@ public class MultiscalesAdapter implements JsonDeserializer<OmeNgffMultiScaleMet
 
 		return obj;
 	}
-
 }

--- a/src/test/java/org/janelia/saalfeldlab/n5/universe/metadata/MetadataUtilsTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/universe/metadata/MetadataUtilsTest.java
@@ -1,0 +1,32 @@
+package org.janelia.saalfeldlab.n5.universe.metadata;
+
+import static org.junit.Assert.assertArrayEquals;
+
+import org.junit.Test;
+
+public class MetadataUtilsTest
+{
+	@Test
+	public void testReversedCopyWithStrings()
+	{
+		String[] input = { "apple", "banana", "cherry" };
+		String[] expected = { "cherry", "banana", "apple" };
+		assertArrayEquals( expected, MetadataUtils.reversedCopy( input ) );
+	}
+
+	@Test
+	public void testReversedCopyWithIntegers()
+	{
+		Integer[] input = { 1, 2, 3, 4, 5 };
+		Integer[] expected = { 5, 4, 3, 2, 1 };
+		assertArrayEquals( expected, MetadataUtils.reversedCopy( input ) );
+	}
+
+	@Test
+	public void testReversedCopyWithEmptyArray()
+	{
+		String[] input = {};
+		String[] expected = {};
+		assertArrayEquals( expected, MetadataUtils.reversedCopy( input ) );
+	}
+}


### PR DESCRIPTION
This PR fixes the following bug: https://github.com/saalfeldlab/n5-viewer/issues/54

I am a bit unsure, if there are any side effects by only re-ordering the axes in the deseralization step, but not in serialization step. Perhaps it should happen there as well.

### OME Zarr v0.5 Metadata deserialization update:
* Modified `MultiscalesAdapter.deserialize` to reverse the order of axes when constructing `OmeNgffMultiScaleMetadata`, ensuring axes are handled in the correct order.

### Array reversal utility:
* Added a generic `reversedCopy` method to `MetadataUtils` for creating reversed copies of arrays.

### Testing:
* Added `MetadataUtilsTest` with unit tests for `reversedCopy`, covering string, integer, and empty arrays.