### PR TITLE
Ambiguous zarr

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,13 +111,13 @@
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
 
-		<n5.version>4.0.0-alpha-12-SNAPSHOT</n5.version>
+		<n5.version>4.0.0-alpha-12</n5.version>
 		<n5-aws-s3.version>4.4.0-alpha-9</n5-aws-s3.version>
 		<n5-blosc.version>2.0.0-alpha-4</n5-blosc.version>
 		<n5-google-cloud.version>5.2.0-alpha-7</n5-google-cloud.version>
-		<n5-hdf5.version>2.3.0-alpha-7-SNAPSHOT</n5-hdf5.version>
-		<n5-imglib2.version>7.1.0-alpha-8-SNAPSHOT</n5-imglib2.version>
-		<n5-zarr.version>2.0.0-alpha-8-SNAPSHOT</n5-zarr.version>
+		<n5-hdf5.version>2.3.0-alpha-7</n5-hdf5.version>
+		<n5-imglib2.version>7.1.0-alpha-8</n5-imglib2.version>
+		<n5-zarr.version>2.0.0-alpha-8</n5-zarr.version>
 		<n5-zstandard.version>2.0.0-alpha-4</n5-zstandard.version>
 
 		<jackson-jq.version>1.0.0-preview.20191208</jackson-jq.version>

--- a/pom.xml
+++ b/pom.xml
@@ -111,13 +111,13 @@
 		<!-- NB: Deploy releases to the SciJava Maven repository. -->
 		<releaseProfiles>sign,deploy-to-scijava</releaseProfiles>
 
-		<n5.version>4.0.0-alpha-11</n5.version>
+		<n5.version>4.0.0-alpha-12-SNAPSHOT</n5.version>
 		<n5-aws-s3.version>4.4.0-alpha-9</n5-aws-s3.version>
-        <n5-google-cloud.version>5.2.0-alpha-7</n5-google-cloud.version>
-		<n5-zarr.version>2.0.0-alpha-7</n5-zarr.version>
-		<n5-hdf5.version>2.3.0-alpha-6</n5-hdf5.version>
 		<n5-blosc.version>2.0.0-alpha-4</n5-blosc.version>
-		<n5-imglib2.version>7.1.0-alpha-7</n5-imglib2.version>
+		<n5-google-cloud.version>5.2.0-alpha-7</n5-google-cloud.version>
+		<n5-hdf5.version>2.3.0-alpha-7-SNAPSHOT</n5-hdf5.version>
+		<n5-imglib2.version>7.1.0-alpha-8-SNAPSHOT</n5-imglib2.version>
+		<n5-zarr.version>2.0.0-alpha-8-SNAPSHOT</n5-zarr.version>
 		<n5-zstandard.version>2.0.0-alpha-4</n5-zstandard.version>
 
 		<jackson-jq.version>1.0.0-preview.20191208</jackson-jq.version>

--- a/src/main/java/org/janelia/saalfeldlab/n5/universe/N5Factory.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/universe/N5Factory.java
@@ -29,13 +29,13 @@ package org.janelia.saalfeldlab.n5.universe;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import com.google.gson.GsonBuilder;
-import com.sun.tools.javac.util.List;
 import net.imglib2.util.Pair;
 import org.apache.commons.lang3.function.TriFunction;
 import org.janelia.saalfeldlab.googlecloud.GoogleCloudUtils;
 import org.janelia.saalfeldlab.n5.FileSystemKeyValueAccess;
 import org.janelia.saalfeldlab.n5.KeyValueAccess;
 import org.janelia.saalfeldlab.n5.N5Exception;
+import org.janelia.saalfeldlab.n5.N5Exception.N5IOException;
 import org.janelia.saalfeldlab.n5.N5KeyValueReader;
 import org.janelia.saalfeldlab.n5.N5KeyValueWriter;
 import org.janelia.saalfeldlab.n5.N5Reader;
@@ -59,6 +59,7 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
@@ -452,13 +453,13 @@ public class N5Factory implements Serializable {
      * @return an N5Reader
      */
 	private N5Reader newGenericZarrReader(final KeyValueAccess access, final URI location) {
-		for (StorageFormat zarrFormat : List.of(ZARR3, ZARR2)) {
+		for (StorageFormat zarrFormat : Arrays.asList(ZARR3, ZARR2)) {
 			try {
 				return openReader(zarrFormat, access, location);
 			} catch (Exception ignored) {
 			}
 		}
-		throw new N5Exception("Unable to open Zarr reader at " + location.toString() + " as N5Reader");
+		throw new N5IOException("Unable to open Zarr reader at " + location.toString() + " as N5Reader");
 	}
 
 	/**
@@ -683,7 +684,7 @@ public class N5Factory implements Serializable {
      * @return the zarr writer
      */
 	private N5Writer newGenericZarrWriter(final KeyValueAccess access, final URI location) {
-		List<StorageFormat> zarrFormats = List.of(ZARR3, ZARR2);
+		List<StorageFormat> zarrFormats = Arrays.asList(ZARR3, ZARR2);
 		for (StorageFormat zarrFormat : zarrFormats) {
 			 /* we dont care about the read, but we do want to prefer a writer over a container that
 			 * exists, rather than creating a new writer; the only way to check is to see if
@@ -701,7 +702,7 @@ public class N5Factory implements Serializable {
 			}
 		}
 
-		throw new N5Exception("Unable to open Zarr writer at " + location.toString() + " as N5Reader");
+		throw new N5IOException("Unable to open Zarr writer at " + location.toString() + " as N5Reader");
 	}
 
 	private <T extends N5Reader> T openN5ContainerWithStorageFormat(

--- a/src/main/java/org/janelia/saalfeldlab/n5/universe/N5Factory.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/universe/N5Factory.java
@@ -29,6 +29,7 @@ package org.janelia.saalfeldlab.n5.universe;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import com.google.gson.GsonBuilder;
+import com.sun.tools.javac.util.List;
 import net.imglib2.util.Pair;
 import org.apache.commons.lang3.function.TriFunction;
 import org.janelia.saalfeldlab.googlecloud.GoogleCloudUtils;
@@ -62,8 +63,7 @@ import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.regex.Pattern;
 
-import static org.janelia.saalfeldlab.n5.universe.StorageFormat.getStorageFromNestedScheme;
-import static org.janelia.saalfeldlab.n5.universe.StorageFormat.guessStorageFromKeys;
+import static org.janelia.saalfeldlab.n5.universe.StorageFormat.*;
 
 /**
  * Factory for various N5 readers and writers. Implementation-specific
@@ -274,7 +274,10 @@ public class N5Factory implements Serializable {
 	 * @param uri uri to the google cloud object
 	 * @return the N5Reader
 	 * @throws URISyntaxException if uri is malformed
+	 *
+	 * @deprecated use {@link N5Factory#openReader(KeyValueAccessBackend, URI)} instead
 	 */
+	@Deprecated
 	public N5Reader openGoogleCloudReader(final String uri) throws URISyntaxException {
 
 		return openN5ContainerWithBackend(KeyValueAccessBackend.GOOGLE_CLOUD, uri, true, this::openReader);
@@ -286,7 +289,10 @@ public class N5Factory implements Serializable {
 	 * @param uri uri to the amazon s3 object
 	 * @return the N5Reader
 	 * @throws URISyntaxException if uri is malformed
+	 *
+	 * @deprecated use {@link N5Factory#openReader(KeyValueAccessBackend, URI)} instead
 	 */
+	@Deprecated
 	public N5Reader openAWSS3Reader(final String uri) throws URISyntaxException {
 
 		return openN5ContainerWithBackend(KeyValueAccessBackend.AWS, uri, true, this::openReader);
@@ -298,10 +304,21 @@ public class N5Factory implements Serializable {
 	 * @param uri uri to the N5Reader
 	 * @return the N5Reader
 	 * @throws URISyntaxException if uri is malformed
+	 *
+	 * @deprecated use {@link N5Factory#openReader(KeyValueAccessBackend, URI)} instead
 	 */
+	@Deprecated
 	public N5Reader openFileSystemReader(final String uri) throws URISyntaxException {
 
 		return openN5ContainerWithBackend(KeyValueAccessBackend.FILE, uri, true, this::openReader);
+	}
+
+	StorageFormat[] orderedStorageFormats() {
+
+		return Arrays.stream(StorageFormat.values()).sorted((l, r) -> {
+			if (l == preferredStorageFormat) return -1;
+			return l.compareTo(r);
+		}).toArray(StorageFormat[]::new);
 	}
 
 	/**
@@ -353,14 +370,39 @@ public class N5Factory implements Serializable {
 		return openN5Container(format, uri, true, this::openReader);
 	}
 
-	StorageFormat[] orderedStorageFormats() {
-
-		return Arrays.stream(StorageFormat.values()).sorted((l, r) -> {
-			if (l == preferredStorageFormat) return -1;
-			return l.compareTo(r);
-		}).toArray(StorageFormat[]::new);
+	/**
+	 * Open and N5Reader at the given URI given the specified {@code KeyValueAccessBackend}.
+	 *
+	 * @param backend key-value access
+	 * @param uri location of reader
+	 * @return the N5Reader
+	 */
+	public N5Reader openReader(final KeyValueAccessBackend backend, final String uri) {
+		final Pair<StorageFormat, URI> storageAndUri = StorageFormat.parseUri(uri);
+		final StorageFormat format = storageAndUri.getA();
+		final URI asUri = storageAndUri.getB();
+		final boolean inferredStorageFormat = format != null && getStorageFromNestedScheme(uri).getA() == null;
+		final KeyValueAccess kva = backend.apply(asUri, this, true);
+		if (inferredStorageFormat) {
+			final StorageFormat inferredFromKeys = guessStorageFromKeys(asUri, kva);
+			final StorageFormat inferredFormat = inferredFromKeys != null ? inferredFromKeys : format;
+			return openReader(inferredFormat, kva, asUri);
+		}
+		return openReader(format, kva, asUri);
 	}
 
+    /**
+	 * Open and N5Reader at the given URI given the specified {@code KeyValueAccessBackend}.
+	 *
+     * @param backend key-value access
+     * @param uri location of reader
+     * @return the N5Reader
+     */
+	public N5Reader openReader(final KeyValueAccessBackend backend, final URI uri) {
+		final KeyValueAccess kva = backend.apply(uri, this, true);
+		final StorageFormat inferredFromKeys = guessStorageFromKeys(uri, kva);
+		return openReader(inferredFromKeys, kva, uri);
+	}
 
 
 	/**
@@ -371,8 +413,7 @@ public class N5Factory implements Serializable {
 	 * @param location root URI of the resulting N5Reader
 	 * @return the N5Reader
 	 */
-	private N5Reader openReader(@Nullable final StorageFormat storage, @Nullable final KeyValueAccess access, URI location) {
-
+	public N5Reader openReader(@Nullable final StorageFormat storage, @Nullable final KeyValueAccess access, URI location) {
 
 		if (storage == null) {
 			for (final StorageFormat format : orderedStorageFormats()) {
@@ -462,7 +503,10 @@ public class N5Factory implements Serializable {
 	 * @param uri uri to the google cloud object
 	 * @return the N5GoogleCloudStorageWriter
 	 * @throws URISyntaxException if uri is malformed
+	 *
+	 * @deprecated use {@link #openWriter(KeyValueAccessBackend, String)} instead.
 	 */
+	@Deprecated
 	public N5Writer openGoogleCloudWriter(final String uri) throws URISyntaxException {
 
 		return openN5ContainerWithBackend(KeyValueAccessBackend.GOOGLE_CLOUD, uri, false, this::openWriter);
@@ -474,7 +518,11 @@ public class N5Factory implements Serializable {
 	 * @param uri uri to the s3 object
 	 * @return the N5Writer
 	 * @throws URISyntaxException if the URI is malformed
+	 *
+	 *
+	 * @deprecated use {@link #openWriter(KeyValueAccessBackend, String)} instead.
 	 */
+	@Deprecated()
 	public N5Writer openAWSS3Writer(final String uri) throws URISyntaxException {
 
 		return openN5ContainerWithBackend(KeyValueAccessBackend.AWS, uri, false, this::openWriter);
@@ -496,10 +544,45 @@ public class N5Factory implements Serializable {
 			final KeyValueAccess kva = getKeyValueAccess(asUri, false);
 			final StorageFormat inferredFromKeys = guessStorageFromKeys(asUri, kva);
 			final StorageFormat inferredFormat = inferredFromKeys != null ? inferredFromKeys : format;
-			return openWriter(inferredFormat, asUri);
+			return openWriter(inferredFormat, kva, asUri);
 		}
 
 		return openWriter(format, asUri);
+	}
+
+	/**
+	 * Create or Open an N5Writer as the given uri and backend.
+	 *
+	 * @param backend key-value access
+	 * @param uri location of writer
+	 * @return the N5Writer
+	 */
+	public N5Writer openWriter(final KeyValueAccessBackend backend, final URI uri) {
+		final KeyValueAccess kva = backend.apply(uri, this, false);
+		final StorageFormat inferredFromKeys = guessStorageFromKeys(uri, kva);
+		return openWriter(inferredFromKeys, kva, uri);
+	}
+
+    /**
+	 * Create or Open an N5Writer as the given uri and backend.
+	 *
+     * @param backend key-value access
+     * @param uri location of writer
+     * @return the N5Writer
+     */
+	public N5Writer openWriter(final KeyValueAccessBackend backend, final String uri) {
+		final Pair<StorageFormat, URI> storageAndUri = StorageFormat.parseUri(uri);
+		final StorageFormat format = storageAndUri.getA();
+		final URI asUri = storageAndUri.getB();
+		final KeyValueAccess kva = backend.apply(asUri, this, false);
+		final boolean inferredStorageFormat = format != null && getStorageFromNestedScheme(uri).getA() == null;
+		if (inferredStorageFormat) {
+			final StorageFormat inferredFromKeys = guessStorageFromKeys(asUri, kva);
+			final StorageFormat inferredFormat = inferredFromKeys != null ? inferredFromKeys : format;
+			return openWriter(inferredFormat, kva, asUri);
+		}
+
+		return openWriter(format, kva, asUri);
 	}
 
 	/**

--- a/src/main/java/org/janelia/saalfeldlab/n5/universe/N5Factory.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/universe/N5Factory.java
@@ -414,7 +414,7 @@ public class N5Factory implements Serializable {
 	 * @param location root URI of the resulting N5Reader
 	 * @return the N5Reader
 	 */
-	public N5Reader openReader(@Nullable final StorageFormat storage, @Nullable final KeyValueAccess access, URI location) {
+	public N5Reader openReader(@Nullable final StorageFormat storage, final KeyValueAccess access, URI location) {
 
 		if (storage == null) {
 			for (final StorageFormat format : orderedStorageFormats()) {
@@ -642,7 +642,7 @@ public class N5Factory implements Serializable {
 	 * @param location root location of the resulting N5Writer
 	 * @return the N5Writer
 	 */
-	public N5Writer openWriter(@Nullable final StorageFormat storage, @Nullable final KeyValueAccess access, final URI location) {
+	public N5Writer openWriter(@Nullable final StorageFormat storage, final KeyValueAccess access, final URI location) {
 
 		if (storage == null) {
 			for (final StorageFormat format : orderedStorageFormats()) {

--- a/src/main/java/org/janelia/saalfeldlab/n5/universe/N5Factory.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/universe/N5Factory.java
@@ -244,7 +244,7 @@ public class N5Factory implements Serializable {
 	@Deprecated
 	public N5Reader openZarrReader(final String path) {
 
-		return openN5ContainerWithStorageFormat(StorageFormat.ZARR2, path, this::openReader);
+		return openN5ContainerWithStorageFormat(StorageFormat.ZARR, path, this::openReader);
 	}
 
 	/**
@@ -430,15 +430,35 @@ public class N5Factory implements Serializable {
 			switch (storage) {
 			case N5:
 				return new N5KeyValueReader(access, containerPath, gsonBuilder, cacheAttributes);
-			case ZARR:
+			case ZARR3:
 				return new ZarrV3KeyValueReader(access,containerPath, gsonBuilder, cacheAttributes);
 			case ZARR2:
 				return new ZarrKeyValueReader(access, containerPath, gsonBuilder, zarrMapN5DatasetAttributes, zarrMergeAttributes, cacheAttributes);
+			case ZARR:
+				return newGenericZarrReader(access, location);
 			case HDF5:
 				return new N5HDF5Reader(containerPath, hdf5OverrideBlockSize, gsonBuilder, hdf5DefaultBlockSize);
 			}
 			return null;
 		}
+	}
+
+    /**
+	 * Open a zarr as N5Reader at the given {@code access} and {@code location}.
+	 * Will prefer returning the newest version of zarr that is found at the location.
+	 *
+     * @param access to the key-value access backend
+     * @param location of the zarr container
+     * @return an N5Reader
+     */
+	private N5Reader newGenericZarrReader(final KeyValueAccess access, final URI location) {
+		for (StorageFormat zarrFormat : List.of(ZARR3, ZARR2)) {
+			try {
+				return openReader(zarrFormat, access, location);
+			} catch (Exception ignored) {
+			}
+		}
+		throw new N5Exception("Unable to open Zarr reader at " + location.toString() + " as N5Reader");
 	}
 
 	/**
@@ -473,7 +493,7 @@ public class N5Factory implements Serializable {
 	@Deprecated
 	public N5Writer openZarrWriter(final String path) {
 
-		return openN5ContainerWithStorageFormat(StorageFormat.ZARR2, path, this::openWriter);
+		return openN5ContainerWithStorageFormat(StorageFormat.ZARR, path, this::openWriter);
 	}
 
 	/**
@@ -636,12 +656,14 @@ public class N5Factory implements Serializable {
 
 			final String containerLocation = location.toString();
 			switch (storage) {
-			case ZARR:
+			case ZARR3:
 				final ZarrV3KeyValueWriter writer = new ZarrV3KeyValueWriter(access, containerLocation, gsonBuilder, cacheAttributes);
 				writer.setDimensionSeparator(zarrDimensionSeparator);
 				return writer;
 			case ZARR2:
 				return new ZarrKeyValueWriter(access, containerLocation, gsonBuilder, zarrMapN5DatasetAttributes, zarrMergeAttributes, zarrDimensionSeparator, cacheAttributes);
+			case ZARR:
+				return newGenericZarrWriter(access, location);
 			case N5:
 				return new N5KeyValueWriter(access, containerLocation, gsonBuilder, cacheAttributes);
 			case HDF5:
@@ -649,6 +671,37 @@ public class N5Factory implements Serializable {
 			}
 		}
 		return null;
+	}
+
+    /**
+	 * Try to get a zarr writer at the given location and access.
+	 * If a container exists at the location, load that version as a writer if possible.
+	 * If no container exists, create a new writer with the newest zarr version.
+	 *
+     * @param access to the key-value backend
+     * @param location of the zarr writer
+     * @return the zarr writer
+     */
+	private N5Writer newGenericZarrWriter(final KeyValueAccess access, final URI location) {
+		List<StorageFormat> zarrFormats = List.of(ZARR3, ZARR2);
+		for (StorageFormat zarrFormat : zarrFormats) {
+			 /* we dont care about the read, but we do want to prefer a writer over a container that
+			 * exists, rather than creating a new writer; the only way to check is to see if
+			 * we can get a valid reader. If we can, try the writer. */
+            try (N5Reader ignore = openReader(zarrFormat, access, location)) {
+                return openWriter(zarrFormat, access, location);
+            } catch (Exception ignored) {
+            }
+		}
+		/* However, if we have no valid readers, then try and return the first valid (created) writer */
+		for (StorageFormat zarrFormat : zarrFormats) {
+			try {
+				return openWriter(zarrFormat, access, location);
+			} catch (Exception ignored) {
+			}
+		}
+
+		throw new N5Exception("Unable to open Zarr writer at " + location.toString() + " as N5Reader");
 	}
 
 	private <T extends N5Reader> T openN5ContainerWithStorageFormat(

--- a/src/main/java/org/janelia/saalfeldlab/n5/universe/N5FactoryWithCache.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/universe/N5FactoryWithCache.java
@@ -2,13 +2,11 @@ package org.janelia.saalfeldlab.n5.universe;
 
 import com.google.gson.JsonElement;
 import net.imglib2.util.Pair;
-import org.janelia.saalfeldlab.n5.CachedGsonKeyValueN5Reader;
-import org.janelia.saalfeldlab.n5.N5KeyValueReader;
-import org.janelia.saalfeldlab.n5.N5Reader;
-import org.janelia.saalfeldlab.n5.N5Writer;
+import org.janelia.saalfeldlab.n5.*;
 import org.janelia.saalfeldlab.n5.hdf5.N5HDF5Reader;
 import org.janelia.saalfeldlab.n5.zarr.ZarrKeyValueReader;
 import org.janelia.saalfeldlab.n5.zarr.v3.ZarrV3KeyValueReader;
+import org.jspecify.annotations.Nullable;
 
 import java.net.URI;
 import java.nio.file.Paths;
@@ -20,36 +18,29 @@ public class N5FactoryWithCache extends N5Factory {
 	private final HashMap<URI, N5Reader> readerCache = new HashMap<>();
 	private final HashMap<URI, N5Writer> writerCache = new HashMap<>();
 
-	@Override public N5Reader openReader(StorageFormat format, URI uri) {
+	@Override
+	public N5Reader openReader(StorageFormat storage, KeyValueAccess access, URI location) {
 
-		final URI normalUri = normalizeUri(uri);
-		final N5Reader reader = getReaderFromCache(format, normalUri);
+		final N5Reader reader = getReaderFromCache(storage, location);
 		if (reader != null)
 			return reader;
-		return openAndCacheReader(format, normalUri);
+		return openAndCacheReader(storage, access, location);
 	}
 
-	@Override public N5Writer openWriter(StorageFormat format, URI uri) {
+	private N5Reader openAndCacheReader(StorageFormat storageFormat, KeyValueAccess access, URI uri) {
 
-		final URI normalUri = normalizeUri(uri);
-		final N5Writer writer = getWriterFromCache(format, normalUri);
-		if (writer != null)
-			return writer;
-		return openAndCacheWriter(format, normalUri);
-	}
-
-	private N5Reader openAndCacheReader(StorageFormat storageFormat, URI uri) {
-
-		final N5Reader reader = super.openReader(storageFormat, uri);
+		final N5Reader reader = super.openReader(storageFormat, access, uri);
 		if (reader == null)
 			return null;
 
-		readerCache.put(uri, reader);
+		URI normalUri = normalizeUri(uri);
+		readerCache.put(normalUri, reader);
 		return reader;
 	}
 
-	protected synchronized N5Reader getReaderFromCache(StorageFormat format, URI uri) {
+	protected synchronized N5Reader getReaderFromCache(StorageFormat format, URI location) {
 
+		final URI uri = normalizeUri(location);
 		final N5Reader reader = readerCache.get(uri);
 		if (reader == null)
 			return null;
@@ -60,6 +51,15 @@ public class N5FactoryWithCache extends N5Factory {
 		}
 
 		return reader;
+	}
+
+	@Override
+	public N5Writer openWriter(StorageFormat storage, KeyValueAccess access, URI location) {
+
+		final N5Writer writer = getWriterFromCache(storage, location);
+		if (writer != null)
+			return writer;
+		return openAndCacheWriter(storage, access, location);
 	}
 
 	private boolean canRead(N5Reader reader) {
@@ -76,25 +76,26 @@ public class N5FactoryWithCache extends N5Factory {
 		}
 	}
 
-	private N5Writer openAndCacheWriter(StorageFormat storageFormat, URI uri) {
+	private N5Writer openAndCacheWriter(StorageFormat storageFormat, KeyValueAccess access, URI uri) {
 
-		final N5Writer writer = super.openWriter(storageFormat, uri);
+		final N5Writer writer = super.openWriter(storageFormat, access, uri);
 		if (writer == null)
 			return null;
 
-		writerCache.put(uri, writer);
+		URI normalUri = normalizeUri(uri);
+		writerCache.put(normalUri, writer);
 		return writer;
 	}
 
 	protected synchronized N5Writer getWriterFromCache(StorageFormat format, URI uri) {
 
-
-		final N5Writer writer = writerCache.get(uri);
+		URI normalUri = normalizeUri(uri);
+		final N5Writer writer = writerCache.get(normalUri);
 		if (writer == null)
 			return null;
 
 		if (!n5MatchesFormat(writer, format) || !canWrite(writer)) {
-			writerCache.remove(uri);
+			writerCache.remove(normalUri);
 			return null;
 		}
 
@@ -136,8 +137,10 @@ public class N5FactoryWithCache extends N5Factory {
 			return reader instanceof N5KeyValueReader && !(reader instanceof ZarrV3KeyValueReader);
 		case ZARR2:
 			return reader instanceof ZarrKeyValueReader;
-		case ZARR:
+		case ZARR3:
 			return reader instanceof ZarrV3KeyValueReader;
+		case ZARR:
+			return reader instanceof ZarrKeyValueReader || reader instanceof ZarrV3KeyValueReader;
 		case HDF5:
 			return reader instanceof N5HDF5Reader;
 		default:

--- a/src/main/java/org/janelia/saalfeldlab/n5/universe/StorageFormat.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/universe/StorageFormat.java
@@ -18,7 +18,8 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 public enum StorageFormat {
-	ZARR(Pattern.compile("zarr(3)?", Pattern.CASE_INSENSITIVE), uri -> Pattern.compile("\\.zarr$", Pattern.CASE_INSENSITIVE).matcher(new File(uri.getPath()).toString()).find()),
+	ZARR(Pattern.compile("zarr", Pattern.CASE_INSENSITIVE), uri -> Pattern.compile("\\.zarr$", Pattern.CASE_INSENSITIVE).matcher(new File(uri.getPath()).toString()).find()),
+	ZARR3(Pattern.compile("zarr3", Pattern.CASE_INSENSITIVE), uri -> Pattern.compile("\\.zarr$", Pattern.CASE_INSENSITIVE).matcher(new File(uri.getPath()).toString()).find()),
 	ZARR2(Pattern.compile("zarr2", Pattern.CASE_INSENSITIVE), uri -> Pattern.compile("\\.zarr$", Pattern.CASE_INSENSITIVE).matcher(new File(uri.getPath()).toString()).find()),
 	N5(Pattern.compile("n5", Pattern.CASE_INSENSITIVE), uri -> Pattern.compile("\\.n5$", Pattern.CASE_INSENSITIVE).matcher(new File(uri.getPath()).toString()).find()),
 	HDF5(Pattern.compile("h(df)?5", Pattern.CASE_INSENSITIVE), uri -> {
@@ -93,7 +94,7 @@ public enum StorageFormat {
 				return StorageFormat.HDF5;
 		} catch (final Exception ignore) {}
 		if (kva.exists(kva.compose(uri, ZARR3_ATTRIBUTES)))
-			return StorageFormat.ZARR;
+			return StorageFormat.ZARR3;
 		if (Arrays.stream(ZARR2_KEYS).anyMatch(it -> kva.exists(kva.compose(uri, it))))
 			return StorageFormat.ZARR2;
 		if (kva.exists(kva.compose(uri, N5_ATTRIBUTES)))

--- a/src/main/java/org/janelia/saalfeldlab/n5/universe/container/ContainerMetadataNode.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/universe/container/ContainerMetadataNode.java
@@ -223,7 +223,7 @@ public class ContainerMetadataNode implements GsonN5Writer {
 	}
 
 	@Override
-	public boolean shardExists(String pathName, DatasetAttributes datasetAttributes, long... gridPosition) throws N5Exception {
+	public boolean blockExists(String pathName, DatasetAttributes datasetAttributes, long... gridPosition) throws N5Exception {
 
 		// Consider throwing exception instead?
 		return false;
@@ -351,12 +351,12 @@ public class ContainerMetadataNode implements GsonN5Writer {
 	}
 
 	@Override
-	public <T> void writeBlock(String pathName, DatasetAttributes datasetAttributes, DataBlock<T> dataBlock) {
-		throw new UnsupportedOperationException("ContainerMetadata does not support writeBlock");
+	public <T> void writeChunk(String pathName, DatasetAttributes datasetAttributes, DataBlock<T> dataBlock) {
+		throw new UnsupportedOperationException("ContainerMetadata does not support writeChunk");
 	}
 	
 	@Override
-	public <T> void writeShard(String pathName, DatasetAttributes datasetAttributes, DataBlock<T> dataBlock) {
+	public <T> void writeBlock(String pathName, DatasetAttributes datasetAttributes, DataBlock<T> dataBlock) {
 		throw new UnsupportedOperationException("ContainerMetadata does not support writeBlock");
 	}
 
@@ -373,6 +373,16 @@ public class ContainerMetadataNode implements GsonN5Writer {
 	}
 
 	@Override
+	public boolean deleteChunk(String pathName, long... gridPosition) {
+		return false;
+	}
+
+	@Override
+	public boolean deleteChunk(String datasetPath, DatasetAttributes datasetAttributes, long... gridPosition) throws N5Exception {
+		return false;
+	}
+
+	@Override
 	public boolean deleteBlock(String pathName, long... gridPosition) {
 		return false;
 	}
@@ -383,12 +393,12 @@ public class ContainerMetadataNode implements GsonN5Writer {
 	}
 
 	@Override
-	public DataBlock<?> readBlock(String pathName, DatasetAttributes datasetAttributes, long... gridPosition) {
+	public DataBlock<?> readChunk(String pathName, DatasetAttributes datasetAttributes, long... gridPosition) {
 		return null;
 	}
 	
 	@Override
-	public DataBlock<?> readShard(String pathName, DatasetAttributes datasetAttributes, long... gridPosition) {
+	public DataBlock<?> readBlock(String pathName, DatasetAttributes datasetAttributes, long... gridPosition) {
 		return null;
 	}
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/universe/translation/TranslatedN5Reader.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/universe/translation/TranslatedN5Reader.java
@@ -63,15 +63,15 @@ public class TranslatedN5Reader implements GsonN5Reader {
 	}
 
 	@Override
-	public DataBlock<?> readBlock(String pathName, DatasetAttributes datasetAttributes, long... gridPosition) {
+	public DataBlock<?> readChunk(String pathName, DatasetAttributes datasetAttributes, long... gridPosition) {
 
-		return n5.readBlock( originalPath( pathName ), datasetAttributes, gridPosition);
+		return n5.readChunk( originalPath( pathName ), datasetAttributes, gridPosition);
 	}
 
 	@Override
-	public DataBlock<?> readShard(String pathName, DatasetAttributes datasetAttributes, long... gridPosition) {
+	public DataBlock<?> readBlock(String pathName, DatasetAttributes datasetAttributes, long... gridPosition) {
 
-		return n5.readShard(originalPath(pathName), datasetAttributes, gridPosition);
+		return n5.readBlock(originalPath(pathName), datasetAttributes, gridPosition);
 	}
 
 	@Override
@@ -80,9 +80,9 @@ public class TranslatedN5Reader implements GsonN5Reader {
 	}
 
 	@Override
-	public boolean shardExists(String pathName, DatasetAttributes datasetAttributes, long... gridPosition) throws N5Exception {
+	public boolean blockExists(String pathName, DatasetAttributes datasetAttributes, long... gridPosition) throws N5Exception {
 
-		return n5.shardExists( originalPath( pathName ), datasetAttributes, gridPosition);
+		return n5.blockExists( originalPath( pathName ), datasetAttributes, gridPosition);
 	}
 
 	@Override

--- a/src/main/java/org/janelia/saalfeldlab/n5/universe/translation/TranslatedN5Writer.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/universe/translation/TranslatedN5Writer.java
@@ -10,7 +10,6 @@ import org.janelia.saalfeldlab.n5.DatasetAttributes;
 import org.janelia.saalfeldlab.n5.GsonN5Writer;
 import org.janelia.saalfeldlab.n5.N5Exception;
 import org.janelia.saalfeldlab.n5.N5Writer;
-import org.janelia.saalfeldlab.n5.N5Writer.DataBlockSupplier;
 import org.janelia.saalfeldlab.n5.universe.container.ContainerMetadataNode;
 import org.janelia.saalfeldlab.n5.universe.container.ContainerMetadataWriter;
 
@@ -118,13 +117,13 @@ public class TranslatedN5Writer extends TranslatedN5Reader implements GsonN5Writ
 	}
 
 	@Override
-	public <T> void writeBlock(String pathName, DatasetAttributes datasetAttributes, DataBlock<T> dataBlock) {
-		writer.writeBlock(originalPath(pathName), datasetAttributes, dataBlock);
+	public <T> void writeChunk(String pathName, DatasetAttributes datasetAttributes, DataBlock<T> dataBlock) {
+		writer.writeChunk(originalPath(pathName), datasetAttributes, dataBlock);
 	}
 
 	@Override
-	public <T> void writeShard(String pathName, DatasetAttributes datasetAttributes, DataBlock<T> dataBlock) {
-		writer.writeShard(originalPath(pathName), datasetAttributes, dataBlock);
+	public <T> void writeBlock(String pathName, DatasetAttributes datasetAttributes, DataBlock<T> dataBlock) {
+		writer.writeBlock(originalPath(pathName), datasetAttributes, dataBlock);
 	}
 
 	@Override
@@ -137,6 +136,16 @@ public class TranslatedN5Writer extends TranslatedN5Reader implements GsonN5Writ
 	public <T> void writeRegion(String datasetPath, DatasetAttributes datasetAttributes, long[] min, long[] size, DataBlockSupplier<T> dataBlocks,
 			boolean writeFully, ExecutorService exec) throws N5Exception, InterruptedException, ExecutionException {
 		writer.writeRegion(datasetPath, datasetAttributes, min, size, dataBlocks, writeFully, exec);
+	}
+
+	@Override
+	public boolean deleteChunk(String pathName, long... gridPosition) {
+		return writer.deleteChunk(originalPath(pathName), gridPosition);
+	}
+
+	@Override
+	public boolean deleteChunk(String datasetPath, DatasetAttributes datasetAttributes, long... gridPosition) throws N5Exception {
+		return writer.deleteChunk(originalPath(datasetPath), datasetAttributes, gridPosition);
 	}
 
 	@Override

--- a/src/test/java/org/janelia/saalfeldlab/n5/universe/N5FactoryTests.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/universe/N5FactoryTests.java
@@ -389,16 +389,16 @@ public class N5FactoryTests {
 			final N5Writer writer2 = cachedFactory.openWriter(tmpPath);
 			assertSame(writer2, writer1);
 
-			final N5Writer writerFromStoragePrefix = cachedFactory.openWriter("zarr:" + tmpPath);
+			final N5Writer writerFromStoragePrefix = cachedFactory.openWriter("zarr3:" + tmpPath);
 			assertSame(writerFromStoragePrefix, writer1);
 
-			final N5Writer writerFromStoragePrefix2 = cachedFactory.openWriter("zarr://" + tmpPath);
+			final N5Writer writerFromStoragePrefix2 = cachedFactory.openWriter("zarr3://" + tmpPath);
 			assertSame(writerFromStoragePrefix2, writer1);
 
 			final N5Writer writerDifferentStorageFormat = cachedFactory.openWriter(StorageFormat.N5, tmpPath);
 			assertNotSame(writerDifferentStorageFormat, writer1);
 
-			final N5Writer writerFromStorageType = cachedFactory.openWriter(StorageFormat.ZARR2, tmpPath);
+			final N5Writer writerFromStorageType = cachedFactory.openWriter(StorageFormat.ZARR3, tmpPath);
 			assertNotSame(writerFromStorageType, writerDifferentStorageFormat);
 			assertNotSame(writerFromStorageType, writer1);
 
@@ -410,16 +410,16 @@ public class N5FactoryTests {
 			final N5Reader reader2 = cachedFactory.openReader(tmpPath);
 			assertSame(reader2, reader1);
 
-			final N5Reader readerFromStoragePrefix = cachedFactory.openReader("zarr:" + tmpPath);
+			final N5Reader readerFromStoragePrefix = cachedFactory.openReader("zarr3:" + tmpPath);
 			assertSame(readerFromStoragePrefix, reader1);
 
-			final N5Reader readerFromStoragePrefix2 = cachedFactory.openReader("zarr://" + tmpPath);
+			final N5Reader readerFromStoragePrefix2 = cachedFactory.openReader("zarr3://" + tmpPath);
 			assertSame(readerFromStoragePrefix2, reader1);
 
 			final N5Reader readerDifferentStorageFormat = cachedFactory.openReader(StorageFormat.N5, tmpPath);
 			assertNotSame(readerDifferentStorageFormat, reader1);
 
-			final N5Reader readerFromStorageType = cachedFactory.openReader(StorageFormat.ZARR2, tmpPath);
+			final N5Reader readerFromStorageType = cachedFactory.openReader(StorageFormat.ZARR3, tmpPath);
 			assertNotSame(readerFromStorageType, readerDifferentStorageFormat);
 			assertNotSame(readerFromStorageType, reader1);
 

--- a/src/test/java/org/janelia/saalfeldlab/n5/universe/N5FactoryTests.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/universe/N5FactoryTests.java
@@ -11,8 +11,10 @@ import org.janelia.saalfeldlab.n5.hdf5.N5HDF5Reader;
 import org.janelia.saalfeldlab.n5.hdf5.N5HDF5Writer;
 import org.janelia.saalfeldlab.n5.zarr.ZarrKeyValueReader;
 import org.janelia.saalfeldlab.n5.zarr.ZarrKeyValueWriter;
+import org.janelia.saalfeldlab.n5.zarr.v3.ZarrV3KeyValueReader;
 import org.janelia.saalfeldlab.n5.zarr.v3.ZarrV3KeyValueWriter;
 import org.junit.Test;
+import org.junit.runners.Parameterized;
 
 import java.io.File;
 import java.io.IOException;
@@ -281,6 +283,42 @@ public class N5FactoryTests {
 	}
 
 	@Test
+	public void testAmbiguousZarrFormat() throws IOException {
+
+		final N5Factory factory = new N5Factory();
+		File tmpDir = Files.createTempDirectory("factory-test-").toFile();
+
+		/* by default, should be zarr 3 with no other information */
+		URI doesntExistsIsZarr3 = tmpDir.toPath().resolve("doesnt_exists_is_zarr3").toUri();
+		N5Writer n5 = factory.openWriter(StorageFormat.ZARR, doesntExistsIsZarr3);
+		assertEquals(ZarrV3KeyValueWriter.class, n5.getClass());
+
+		/* If a zarr2 container exists, it should correctly return zarr2 */
+		URI explicitZarr2 = tmpDir.toPath().resolve("explicit_zarr2").toUri();
+		N5Writer explicitZarr2n5 = factory.openWriter(StorageFormat.ZARR2, explicitZarr2);
+		assertEquals(ZarrKeyValueWriter.class, explicitZarr2n5.getClass());
+
+		N5Reader guessZarr2Reader = factory.openReader(StorageFormat.ZARR, explicitZarr2);
+		assertEquals(ZarrKeyValueReader.class, guessZarr2Reader.getClass());
+
+		N5Reader guessZarr2Writer = factory.openWriter(StorageFormat.ZARR, explicitZarr2);
+		assertEquals(ZarrKeyValueWriter.class, guessZarr2Writer.getClass());
+
+		/* If zarr container is valid Zarr2 and Zarr3, should return zarr3 preferentially */
+		URI bothZarrs = tmpDir.toPath().resolve("both_zarr2_zarr3").toUri();
+		N5Writer bothZarr2 = factory.openWriter(StorageFormat.ZARR2, bothZarrs);
+		assertEquals(ZarrKeyValueReader.class, factory.openReader(StorageFormat.ZARR, bothZarrs).getClass());
+		assertEquals(ZarrKeyValueWriter.class, factory.openWriter(StorageFormat.ZARR, bothZarrs).getClass());
+
+		N5Writer bothZarr3 = factory.openWriter(StorageFormat.ZARR3, bothZarrs);
+		assertEquals(ZarrV3KeyValueReader.class, factory.openReader(StorageFormat.ZARR, bothZarrs).getClass());
+		assertEquals(ZarrV3KeyValueWriter.class, factory.openWriter(StorageFormat.ZARR, bothZarrs).getClass());
+
+		assertEquals(ZarrKeyValueReader.class, factory.openReader(StorageFormat.ZARR2, bothZarrs).getClass());
+		assertEquals(ZarrKeyValueWriter.class, factory.openWriter(StorageFormat.ZARR2, bothZarrs).getClass());
+	}
+
+	@Test
 	public void testForExistingWriters() throws IOException {
 
 		final N5Factory factory = new N5Factory();
@@ -292,7 +330,7 @@ public class N5FactoryTests {
 			final Object[][] testData = new Object[][] {
 					{"h5WithWeirdExtension.zarr", StorageFormat.HDF5, N5HDF5Writer.class},
 					{"zarr2WithWeirdExtension.n5", StorageFormat.ZARR2, ZarrKeyValueWriter.class},
-					{"zarr3WithWeirdExtension.jpg", StorageFormat.ZARR, ZarrV3KeyValueWriter.class},
+					{"zarr3WithWeirdExtension.jpg", StorageFormat.ZARR3, ZarrV3KeyValueWriter.class},
 					{"n5WithWeirdExtension.h5", StorageFormat.N5, N5KeyValueWriter.class},
 			};
 

--- a/src/test/java/org/janelia/saalfeldlab/n5/universe/StorageSchemeWrappedN5Test.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/universe/StorageSchemeWrappedN5Test.java
@@ -28,7 +28,7 @@ public interface StorageSchemeWrappedN5Test {
 		final String uriWithStorageScheme = prependStorageScheme(uri);
 		final GsonKeyValueN5Writer writer = (GsonKeyValueN5Writer)getFactory().openWriter(uriWithStorageScheme);
 		switch (getStorageFormat()){
-		case ZARR:
+		case ZARR3:
 			assertTrue(writer instanceof ZarrV3KeyValueWriter);
 			break;
 		case ZARR2:

--- a/src/test/java/org/janelia/saalfeldlab/n5/universe/storage/zarr/ZarrStorageTests.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/universe/storage/zarr/ZarrStorageTests.java
@@ -55,7 +55,7 @@ public class ZarrStorageTests {
 
 		@Override public StorageFormat getStorageFormat() {
 
-			return StorageFormat.ZARR;
+			return StorageFormat.ZARR3;
 		}
 
 		@Override protected N5Writer createN5Writer() {

--- a/src/test/java/org/janelia/saalfeldlab/n5/universe/storage/zarr/zarr3/Zarr3HttpFactoryTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/universe/storage/zarr/zarr3/Zarr3HttpFactoryTest.java
@@ -111,7 +111,7 @@ public class Zarr3HttpFactoryTest extends ZarrStorageTests.Zarr3FactoryTest {
 		final GsonKeyValueN5Writer writer = (GsonKeyValueN5Writer)getFactory().openWriter(uriWithStorageScheme);
 		final GsonKeyValueN5Reader reader = (GsonKeyValueN5Reader)getReader(uri);
 		switch (getStorageFormat()) {
-		case ZARR:
+		case ZARR3:
 			assertTrue(writer instanceof ZarrV3KeyValueWriter);
 			return new ZarrV3HttpReaderFsWriter((ZarrV3KeyValueWriter)writer, (ZarrV3KeyValueReader)reader);
 		case ZARR2:


### PR DESCRIPTION
Introduces ZARR3 as an explicit zarr v3 storage format. Also repurposed ZARR to mean generally "prefer the newest zarr version, but fallback in order"

This also introduces openReader/Writer(KeyValueAccessBackend, URI) methods, and deprecates the numerous backend-specific method (openGoogleCloudReader/Writer, openAwsReader/Writer, etc.)