### PR TITLE
Introduce `N5FactoryOptions` for configurable `N5Factory` behavior

### DIFF
--- a/src/main/java/org/janelia/saalfeldlab/n5/universe/N5Factory.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/universe/N5Factory.java
@@ -36,20 +36,16 @@ import org.janelia.saalfeldlab.n5.FileSystemKeyValueAccess;
 import org.janelia.saalfeldlab.n5.KeyValueAccess;
 import org.janelia.saalfeldlab.n5.N5Exception;
 import org.janelia.saalfeldlab.n5.N5Exception.N5IOException;
-import org.janelia.saalfeldlab.n5.N5KeyValueReader;
-import org.janelia.saalfeldlab.n5.N5KeyValueWriter;
 import org.janelia.saalfeldlab.n5.N5Reader;
 import org.janelia.saalfeldlab.n5.N5URI;
 import org.janelia.saalfeldlab.n5.N5Writer;
 import org.janelia.saalfeldlab.n5.hdf5.N5HDF5Reader;
 import org.janelia.saalfeldlab.n5.hdf5.N5HDF5Writer;
 import org.janelia.saalfeldlab.n5.s3.AmazonS3Utils;
+import org.janelia.saalfeldlab.n5.universe.options.*;
 import org.janelia.saalfeldlab.n5.zarr.N5ZarrReader;
 import org.janelia.saalfeldlab.n5.zarr.N5ZarrWriter;
 import org.janelia.saalfeldlab.n5.zarr.ZarrKeyValueReader;
-import org.janelia.saalfeldlab.n5.zarr.ZarrKeyValueWriter;
-import org.janelia.saalfeldlab.n5.zarr.v3.ZarrV3KeyValueReader;
-import org.janelia.saalfeldlab.n5.zarr.v3.ZarrV3KeyValueWriter;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.S3ClientBuilder;
 
@@ -76,64 +72,102 @@ import static org.janelia.saalfeldlab.n5.universe.StorageFormat.*;
  * @author John Bogovic
  * @author Igor Pisarev
  */
+@SuppressWarnings("UnusedReturnValue")
 public class N5Factory implements Serializable {
 
 	static final N5Factory FACTORY = new N5Factory();
+    private N5FactoryOptions options = new N5FactoryOptions();
 
 	private static final long serialVersionUID = -6823715427289454617L;
 	final static Pattern HTTPS_SCHEME = Pattern.compile("http(s)?", Pattern.CASE_INSENSITIVE);
 	final static Pattern FILE_SCHEME = Pattern.compile("file", Pattern.CASE_INSENSITIVE);
-	private int[] hdf5DefaultBlockSize = {64, 64, 64, 1, 1};
-	private boolean hdf5OverrideBlockSize = false;
-	private GsonBuilder gsonBuilder = new GsonBuilder();
-	private boolean cacheAttributes = true;
-	private String zarrDimensionSeparator = ".";
-	private boolean zarrMapN5DatasetAttributes = true;
-	private boolean zarrMergeAttributes = true;
 	private String googleCloudProjectId = null;
 	private StorageFormat preferredStorageFormat = null;
 	private Consumer<S3ClientBuilder> s3BuilderConfig;
 	private Consumer<StorageOptions.Builder> gcsBuilderConfig;
 
+    public N5FactoryOptions getOptions() {
+
+        return options;
+    }
+
+    public void setOptions(N5FactoryOptions options) {
+        this.options = options;
+    }
+
+    /**
+     * @deprecated configure with {@link N5Factory#getOptions()} and {@link N5FactoryOptions#hdf5(Consumer)}
+     */
 	public N5Factory hdf5DefaultBlockSize(final int... blockSize) {
 
-		hdf5DefaultBlockSize = blockSize;
+        getOptions().hdf5(opts -> opts.defaultBlockSize(blockSize));
 		return this;
 	}
 
+    /**
+     * @deprecated configure with {@link N5Factory#getOptions()} and {@link N5FactoryOptions#hdf5(Consumer)}
+     */
 	public N5Factory hdf5OverrideBlockSize(final boolean override) {
 
-		hdf5OverrideBlockSize = override;
+        getOptions().hdf5(opts -> opts.overrideBlockSize(override));
 		return this;
 	}
 
+    /**
+     * @deprecated configure with {@link N5Factory#getOptions()} and {@link N5FactoryOptions#gsonBuilder(GsonBuilder)}
+     */
 	public N5Factory gsonBuilder(final GsonBuilder gsonBuilder) {
 
-		this.gsonBuilder = gsonBuilder;
+        options.gsonBuilder(gsonBuilder);
 		return this;
 	}
 
+    /**
+     * @deprecated configure with {@link N5Factory#getOptions()} and {@link N5FactoryOptions#cacheAttributes(boolean)}
+     */
 	public N5Factory cacheAttributes(final boolean cacheAttributes) {
 
-		this.cacheAttributes = cacheAttributes;
+        options.cacheAttributes(cacheAttributes);
 		return this;
 	}
 
+
+    /**
+     * Deprecated method to set dimensions separator for zarr 2 writers.
+     *
+     * @param separator to use for Zarr2 dimension separator
+     * @deprecated configure with {@link N5Factory#getOptions()}, {@link N5FactoryOptions#zarr2(Consumer)}, {@link Zarr2Builder#dimensionSeparator(String)}
+     */
 	public N5Factory zarrDimensionSeparator(final String separator) {
 
-		zarrDimensionSeparator = separator;
+        getOptions().zarr2(options -> options.dimensionSeparator(separator));
 		return this;
 	}
 
+    /**
+     * Value to set for the [mapN5DatasetAttributes] parameter of ZarrKeyValueReader.
+     * NOTE: this is only used for Zarr2 readers, not Zarr3
+     *
+     * @param mapAttributes see {@link ZarrKeyValueReader#getAttributes(String)}
+     * @deprecated configure with {@link N5Factory#getOptions()}, {@link N5FactoryOptions#zarr2(Consumer)}, {@link Zarr2Builder#mapN5DatasetAttributes(boolean)}
+	 */
 	public N5Factory zarrMapN5Attributes(final boolean mapAttributes) {
 
-		zarrMapN5DatasetAttributes = mapAttributes;
+        getOptions().zarr2(options -> options.mapN5DatasetAttributes(mapAttributes));
 		return this;
 	}
 
+
+    /**
+     * Value to set for the [mergeAttributes] parameter of ZarrKeyValueReader.
+     * NOTE: this is only used for Zarr2 readers, not Zarr3
+     *
+     * @param mergeAttributes see {@link ZarrKeyValueReader#getAttributes(String)}
+	 * @deprecated configure with {@link N5Factory#getOptions()}, {@link N5FactoryOptions#zarr2(Consumer)}, {@link Zarr2Builder#mergeAttributes(boolean)}
+	 */
 	public N5Factory zarrMergeAttributes(final boolean mergeAttributes) {
 
-		zarrMergeAttributes = mergeAttributes;
+        getOptions().zarr2(options -> options.mergeAttributes(mergeAttributes));
 		return this;
 	}
 
@@ -274,12 +308,10 @@ public class N5Factory implements Serializable {
 	 *
 	 * @param uri uri to the google cloud object
 	 * @return the N5Reader
-	 * @throws URISyntaxException if uri is malformed
-	 *
 	 * @deprecated use {@link N5Factory#openReader(KeyValueAccessBackend, URI)} instead
 	 */
 	@Deprecated
-	public N5Reader openGoogleCloudReader(final String uri) throws URISyntaxException {
+	public N5Reader openGoogleCloudReader(final String uri) {
 
 		return openN5ContainerWithBackend(KeyValueAccessBackend.GOOGLE_CLOUD, uri, true, this::openReader);
 	}
@@ -289,12 +321,10 @@ public class N5Factory implements Serializable {
 	 *
 	 * @param uri uri to the amazon s3 object
 	 * @return the N5Reader
-	 * @throws URISyntaxException if uri is malformed
-	 *
 	 * @deprecated use {@link N5Factory#openReader(KeyValueAccessBackend, URI)} instead
 	 */
 	@Deprecated
-	public N5Reader openAWSS3Reader(final String uri) throws URISyntaxException {
+	public N5Reader openAWSS3Reader(final String uri) {
 
 		return openN5ContainerWithBackend(KeyValueAccessBackend.AWS, uri, true, this::openReader);
 	}
@@ -304,12 +334,10 @@ public class N5Factory implements Serializable {
 	 *
 	 * @param uri uri to the N5Reader
 	 * @return the N5Reader
-	 * @throws URISyntaxException if uri is malformed
-	 *
 	 * @deprecated use {@link N5Factory#openReader(KeyValueAccessBackend, URI)} instead
 	 */
 	@Deprecated
-	public N5Reader openFileSystemReader(final String uri) throws URISyntaxException {
+	public N5Reader openFileSystemReader(final String uri) {
 
 		return openN5ContainerWithBackend(KeyValueAccessBackend.FILE, uri, true, this::openReader);
 	}
@@ -428,19 +456,20 @@ public class N5Factory implements Serializable {
 		} else {
 
 			final String containerPath = location.toString();
+
 			switch (storage) {
-			case N5:
-				return new N5KeyValueReader(access, containerPath, gsonBuilder, cacheAttributes);
-			case ZARR3:
-				return new ZarrV3KeyValueReader(access,containerPath, gsonBuilder, cacheAttributes);
-			case ZARR2:
-				return new ZarrKeyValueReader(access, containerPath, gsonBuilder, zarrMapN5DatasetAttributes, zarrMergeAttributes, cacheAttributes);
-			case ZARR:
-				return newGenericZarrReader(access, location);
-			case HDF5:
-				return new N5HDF5Reader(containerPath, hdf5OverrideBlockSize, gsonBuilder, hdf5DefaultBlockSize);
-			}
-			return null;
+                case HDF5:
+                    return getOptions().getHdf5Builder().buildReader(containerPath);
+                case N5:
+                    return getOptions().getN5Builder().buildReader(access, containerPath);
+                case ZARR3:
+                    return getOptions().getZarr3Builder().buildReader(access, containerPath);
+                case ZARR2:
+                    return getOptions().getZarr2Builder().buildReader(access, containerPath);
+                case ZARR:
+                    return newGenericZarrReader(access, location);
+            }
+            return null;
 		}
 	}
 
@@ -523,12 +552,10 @@ public class N5Factory implements Serializable {
 	 *
 	 * @param uri uri to the google cloud object
 	 * @return the N5GoogleCloudStorageWriter
-	 * @throws URISyntaxException if uri is malformed
-	 *
 	 * @deprecated use {@link #openWriter(KeyValueAccessBackend, String)} instead.
 	 */
 	@Deprecated
-	public N5Writer openGoogleCloudWriter(final String uri) throws URISyntaxException {
+	public N5Writer openGoogleCloudWriter(final String uri) {
 
 		return openN5ContainerWithBackend(KeyValueAccessBackend.GOOGLE_CLOUD, uri, false, this::openWriter);
 	}
@@ -538,13 +565,10 @@ public class N5Factory implements Serializable {
 	 *
 	 * @param uri uri to the s3 object
 	 * @return the N5Writer
-	 * @throws URISyntaxException if the URI is malformed
-	 *
-	 *
 	 * @deprecated use {@link #openWriter(KeyValueAccessBackend, String)} instead.
 	 */
 	@Deprecated()
-	public N5Writer openAWSS3Writer(final String uri) throws URISyntaxException {
+	public N5Writer openAWSS3Writer(final String uri) {
 
 		return openN5ContainerWithBackend(KeyValueAccessBackend.AWS, uri, false, this::openWriter);
 	}
@@ -657,19 +681,17 @@ public class N5Factory implements Serializable {
 
 			final String containerLocation = location.toString();
 			switch (storage) {
-			case ZARR3:
-				final ZarrV3KeyValueWriter writer = new ZarrV3KeyValueWriter(access, containerLocation, gsonBuilder, cacheAttributes);
-				writer.setDimensionSeparator(zarrDimensionSeparator);
-				return writer;
-			case ZARR2:
-				return new ZarrKeyValueWriter(access, containerLocation, gsonBuilder, zarrMapN5DatasetAttributes, zarrMergeAttributes, zarrDimensionSeparator, cacheAttributes);
-			case ZARR:
-				return newGenericZarrWriter(access, location);
-			case N5:
-				return new N5KeyValueWriter(access, containerLocation, gsonBuilder, cacheAttributes);
-			case HDF5:
-				return new N5HDF5Writer(containerLocation, hdf5OverrideBlockSize, gsonBuilder, hdf5DefaultBlockSize);
-			}
+                case HDF5:
+                    return options.getHdf5Builder().buildWriter(containerLocation);
+                case N5:
+                    return options.getN5Builder().buildWriter(access, containerLocation);
+                case ZARR3:
+                    return options.getZarr3Builder().buildWriter(access, containerLocation);
+                case ZARR2:
+                    return options.getZarr2Builder().buildWriter(access, containerLocation);
+                case ZARR:
+                    return newGenericZarrWriter(access, location);
+            }
 		}
 		return null;
 	}

--- a/src/main/java/org/janelia/saalfeldlab/n5/universe/N5Factory.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/universe/N5Factory.java
@@ -26,6 +26,7 @@
  */
 package org.janelia.saalfeldlab.n5.universe;
 
+import com.google.cloud.resourcemanager.v3.CreateTagHoldMetadata;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import com.google.gson.GsonBuilder;
@@ -91,9 +92,15 @@ public class N5Factory implements Serializable {
         return options;
     }
 
-    public void setOptions(N5FactoryOptions options) {
+    public N5Factory setOptions(N5FactoryOptions options) {
         this.options = options;
+		return this;
     }
+
+	public N5Factory options( Consumer<N5FactoryOptions> configureOptions) {
+		configureOptions.accept(options);
+		return this;
+	}
 
     /**
      * @deprecated configure with {@link N5Factory#getOptions()} and {@link N5FactoryOptions#hdf5(Consumer)}

--- a/src/main/java/org/janelia/saalfeldlab/n5/universe/N5Factory.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/universe/N5Factory.java
@@ -26,7 +26,6 @@
  */
 package org.janelia.saalfeldlab.n5.universe;
 
-import com.google.cloud.resourcemanager.v3.CreateTagHoldMetadata;
 import com.google.cloud.storage.Storage;
 import com.google.cloud.storage.StorageOptions;
 import com.google.gson.GsonBuilder;

--- a/src/main/java/org/janelia/saalfeldlab/n5/universe/options/AbstractN5Builder.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/universe/options/AbstractN5Builder.java
@@ -1,0 +1,30 @@
+package org.janelia.saalfeldlab.n5.universe.options;
+
+import com.google.gson.GsonBuilder;
+
+@SuppressWarnings("UnusedReturnValue")
+public abstract class AbstractN5Builder {
+
+    protected Boolean cacheAttributes = null;
+    protected GsonBuilder gsonBuilder = null;
+
+    final protected AbstractN5Builder sharedOptions;
+
+    AbstractN5Builder(AbstractN5Builder sharedOptions) {
+        this.sharedOptions = sharedOptions;
+    }
+
+    public abstract AbstractN5Builder cacheAttributes(boolean cacheAttributes);
+
+    public abstract AbstractN5Builder gsonBuilder(GsonBuilder gsonBuilder);
+
+    public boolean getCacheAttributes() {
+        return cacheAttributes != null ? cacheAttributes : sharedOptions.getCacheAttributes();
+    }
+
+    public GsonBuilder getGsonBuilder() {
+        return gsonBuilder != null ? gsonBuilder : sharedOptions.getGsonBuilder();
+    }
+}
+
+

--- a/src/main/java/org/janelia/saalfeldlab/n5/universe/options/HDF5Builder.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/universe/options/HDF5Builder.java
@@ -1,0 +1,54 @@
+package org.janelia.saalfeldlab.n5.universe.options;
+
+import com.google.gson.GsonBuilder;
+import org.janelia.saalfeldlab.n5.hdf5.N5HDF5Reader;
+import org.janelia.saalfeldlab.n5.hdf5.N5HDF5Writer;
+
+@SuppressWarnings("UnusedReturnValue")
+public class HDF5Builder extends AbstractN5Builder {
+
+    protected int[] defaultBlockSize = new int[]{64, 64, 64, 1, 1};
+    protected boolean overrideBlockSize = false;
+
+    HDF5Builder(AbstractN5Builder sharedOptions) {
+        super(sharedOptions);
+    }
+
+    @Override
+    public HDF5Builder cacheAttributes(boolean cacheAttributes) {
+        this.cacheAttributes = cacheAttributes;
+        return this;
+    }
+
+    @Override
+    public HDF5Builder gsonBuilder(GsonBuilder gsonBuilder) {
+        this.gsonBuilder = gsonBuilder;
+        return this;
+    }
+
+    public HDF5Builder defaultBlockSize(int[] defaultBlockSize) {
+        this.defaultBlockSize = defaultBlockSize.clone();
+        return this;
+    }
+
+    public HDF5Builder overrideBlockSize(boolean overrideBlockSize) {
+        this.overrideBlockSize = overrideBlockSize;
+        return this;
+    }
+
+    public int[] getDefaultBlockSize() {
+        return defaultBlockSize.clone();
+    }
+
+    public boolean getOverrideBlockSize() {
+        return overrideBlockSize;
+    }
+
+    public N5HDF5Writer buildWriter(String containerLocation) {
+        return new N5HDF5Writer(containerLocation, getOverrideBlockSize(), getGsonBuilder(), getDefaultBlockSize());
+    }
+
+    public N5HDF5Reader buildReader(String containerPath) {
+        return new N5HDF5Reader(containerPath, getOverrideBlockSize(), getGsonBuilder(), getDefaultBlockSize());
+    }
+}

--- a/src/main/java/org/janelia/saalfeldlab/n5/universe/options/N5Builder.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/universe/options/N5Builder.java
@@ -1,0 +1,34 @@
+package org.janelia.saalfeldlab.n5.universe.options;
+
+import com.google.gson.GsonBuilder;
+import org.janelia.saalfeldlab.n5.KeyValueAccess;
+import org.janelia.saalfeldlab.n5.N5KeyValueReader;
+import org.janelia.saalfeldlab.n5.N5KeyValueWriter;
+
+@SuppressWarnings("UnusedReturnValue")
+public class N5Builder extends AbstractN5Builder {
+
+    N5Builder(AbstractN5Builder sharedOptions) {
+        super(sharedOptions);
+    }
+
+    @Override
+    public N5Builder cacheAttributes(boolean cacheAttributes) {
+        this.cacheAttributes = cacheAttributes;
+        return this;
+    }
+
+    @Override
+    public N5Builder gsonBuilder(GsonBuilder gsonBuilder) {
+        this.gsonBuilder = gsonBuilder;
+        return this;
+    }
+
+    public N5KeyValueWriter buildWriter(KeyValueAccess access, String containerLocation) {
+        return new N5KeyValueWriter(access, containerLocation, getGsonBuilder(), getCacheAttributes());
+    }
+
+    public N5KeyValueReader buildReader(KeyValueAccess access, String containerLocation) {
+        return new N5KeyValueReader(access, containerLocation, getGsonBuilder(), getCacheAttributes());
+    }
+}

--- a/src/main/java/org/janelia/saalfeldlab/n5/universe/options/N5FactoryOptions.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/universe/options/N5FactoryOptions.java
@@ -1,0 +1,124 @@
+package org.janelia.saalfeldlab.n5.universe.options;
+
+import com.google.gson.GsonBuilder;
+
+import java.util.function.Consumer;
+
+public class N5FactoryOptions {
+
+    private final AbstractN5Builder sharedOptions = new DefaultSharedBuilder();
+
+    private final N5Builder n5Builder = new N5Builder(sharedOptions);
+    private final HDF5Builder hdf5Builder = new HDF5Builder(sharedOptions);
+    private final Zarr2Builder zarr2Builder = new Zarr2Builder(sharedOptions);
+    private final Zarr3Builder zarr3Builder = new Zarr3Builder(sharedOptions);
+
+    /**
+     * Configure {@link N5Builder} to be used when the factory accesses an N5 container.
+     *
+     * @param configure a {@code Consumer<N5Builder>} and performs custom configuration on it
+     * @return the current instance of {@code N5FactoryOptions}
+     */
+    public N5FactoryOptions n5(Consumer<N5Builder> configure) {
+
+        configure.accept(getN5Builder());
+        return this;
+    }
+
+    /**
+     * Configure {@link HDF5Builder} to be used when the factory accesses an HDF5 container.
+     *
+     * @param configure a {@code Consumer<HDF5Builder>} and performs custom configuration on it
+     * @return the current instance of {@code N5FactoryOptions}
+     */
+    public N5FactoryOptions hdf5(Consumer<HDF5Builder> configure) {
+
+        configure.accept(getHdf5Builder());
+        return this;
+    }
+
+    /**
+     * Configure {@link Zarr2Builder} to be used when the factory accesses a Zarr2 container.
+     *
+     * @param configure a {@code Consumer<Zarr2Builder>} and performs custom configuration on it
+     * @return the current instance of {@code N5FactoryOptions}
+     */
+    public N5FactoryOptions zarr2(Consumer<Zarr2Builder> configure) {
+
+        configure.accept(getZarr2Builder());
+        return this;
+    }
+
+    /**
+     * Configure {@link Zarr3Builder} to be used when the factory accesses a Zarr3 container.
+     *
+     * @param configure a {@code Consumer<Zarr3Builder>} and performs custom configuration on it
+     * @return the current instance of {@code N5FactoryOptions}
+     */
+    public N5FactoryOptions zarr3(Consumer<Zarr3Builder> configure) {
+
+        configure.accept(getZarr3Builder());
+        return this;
+    }
+
+    /**
+     * Set the attributes caching behavior. Will be overridden by any format-specific configurations
+     *
+     * @param cacheAttributes flag to use for otherwise unconfigured N5Readers
+     * @return this
+     */
+    public N5FactoryOptions cacheAttributes(boolean cacheAttributes) {
+
+        sharedOptions.cacheAttributes(cacheAttributes);
+        return this;
+    }
+
+    /**
+     * Set the default GsonBuilder. Will be overridden by any format-specific configurations
+     *
+     * @param gsonBuilder to use for otherwise unconfigured N5Readers
+     * @return this
+     */
+    public N5FactoryOptions gsonBuilder(GsonBuilder gsonBuilder) {
+
+        sharedOptions.gsonBuilder(gsonBuilder);
+        return this;
+    }
+
+
+    public N5Builder getN5Builder() {
+        return n5Builder;
+    }
+
+    public HDF5Builder getHdf5Builder() {
+        return hdf5Builder;
+    }
+
+    public Zarr2Builder getZarr2Builder() {
+        return zarr2Builder;
+    }
+
+    public Zarr3Builder getZarr3Builder() {
+        return zarr3Builder;
+    }
+
+    private static class DefaultSharedBuilder extends AbstractN5Builder {
+        public DefaultSharedBuilder() {
+            super(null);
+            cacheAttributes = true;
+            gsonBuilder = new GsonBuilder();
+        }
+
+        @Override
+        public DefaultSharedBuilder cacheAttributes(boolean cacheAttributes) {
+            this.cacheAttributes = cacheAttributes;
+            return this;
+        }
+
+        @Override
+        public DefaultSharedBuilder gsonBuilder(GsonBuilder gsonBuilder) {
+            this.gsonBuilder = gsonBuilder;
+            return this;
+        }
+    }
+}

--- a/src/main/java/org/janelia/saalfeldlab/n5/universe/options/Zarr2Builder.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/universe/options/Zarr2Builder.java
@@ -1,0 +1,65 @@
+package org.janelia.saalfeldlab.n5.universe.options;
+
+import com.google.gson.GsonBuilder;
+import org.janelia.saalfeldlab.n5.KeyValueAccess;
+import org.janelia.saalfeldlab.n5.zarr.ZarrKeyValueReader;
+import org.janelia.saalfeldlab.n5.zarr.ZarrKeyValueWriter;
+
+@SuppressWarnings("UnusedReturnValue")
+public class Zarr2Builder extends ZarrBuilder {
+
+    static final String DEFAULT_DIMENSION_SEPARATOR = ".";
+
+    protected boolean mapN5DatasetAttributes = true;
+    protected boolean mergeAttributes = true;
+
+    Zarr2Builder(AbstractN5Builder sharedOptions) {
+        super(sharedOptions, DEFAULT_DIMENSION_SEPARATOR);
+    }
+
+    public boolean getMapN5DatasetAttributes() {
+        return mapN5DatasetAttributes;
+    }
+
+    public boolean getMergeAttributes() {
+        return mergeAttributes;
+    }
+
+    @Override
+    public Zarr2Builder cacheAttributes(boolean cacheAttributes) {
+        this.cacheAttributes = cacheAttributes;
+        return this;
+    }
+
+    @Override
+    public Zarr2Builder gsonBuilder(GsonBuilder gsonBuilder) {
+        this.gsonBuilder = gsonBuilder;
+        return this;
+    }
+
+    @Override
+    public Zarr2Builder dimensionSeparator(String dimensionSeparator) {
+        this.dimensionSeparator = dimensionSeparator;
+        return this;
+    }
+
+    public Zarr2Builder mapN5DatasetAttributes(boolean mapN5DatasetAttributes) {
+        this.mapN5DatasetAttributes = mapN5DatasetAttributes;
+        return this;
+    }
+
+    public Zarr2Builder mergeAttributes(boolean mergeAttributes) {
+        this.mergeAttributes = mergeAttributes;
+        return this;
+    }
+
+    public ZarrKeyValueWriter buildWriter(KeyValueAccess access, String containerLocation) {
+        return new ZarrKeyValueWriter(access, containerLocation, getGsonBuilder(), getMapN5DatasetAttributes(), getMergeAttributes(), getDimensionSeparator(), getCacheAttributes());
+    }
+
+    public ZarrKeyValueReader buildReader(KeyValueAccess access, String containerLocation) {
+        return new ZarrKeyValueReader(access, containerLocation, getGsonBuilder(), getMapN5DatasetAttributes(), getMergeAttributes(), getCacheAttributes());
+    }
+
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/n5/universe/options/Zarr3Builder.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/universe/options/Zarr3Builder.java
@@ -1,0 +1,47 @@
+package org.janelia.saalfeldlab.n5.universe.options;
+
+import com.google.gson.GsonBuilder;
+import org.janelia.saalfeldlab.n5.KeyValueAccess;
+import org.janelia.saalfeldlab.n5.zarr.v3.ZarrV3KeyValueReader;
+import org.janelia.saalfeldlab.n5.zarr.v3.ZarrV3KeyValueWriter;
+
+@SuppressWarnings("UnusedReturnValue")
+public class Zarr3Builder extends ZarrBuilder {
+
+    static final String DEFAULT_DIMENSION_SEPARATOR = "/";
+
+    Zarr3Builder(AbstractN5Builder sharedOptions) {
+        super(sharedOptions, DEFAULT_DIMENSION_SEPARATOR);
+    }
+
+    @Override
+    public Zarr3Builder cacheAttributes(boolean cacheAttributes) {
+        this.cacheAttributes = cacheAttributes;
+        return this;
+    }
+
+    @Override
+    public Zarr3Builder gsonBuilder(GsonBuilder gsonBuilder) {
+        this.gsonBuilder = gsonBuilder;
+        return this;
+    }
+
+    @Override
+    public Zarr3Builder dimensionSeparator(String dimensionSeparator) {
+        this.dimensionSeparator = dimensionSeparator;
+        return this;
+    }
+
+    public ZarrV3KeyValueWriter buildWriter(KeyValueAccess access, String containerLocation) {
+        ZarrV3KeyValueWriter writer = new ZarrV3KeyValueWriter(access, containerLocation, getGsonBuilder(), getCacheAttributes());
+        writer.setDimensionSeparator(getDimensionSeparator());
+        return writer;
+    }
+
+    public ZarrV3KeyValueReader buildReader(KeyValueAccess access, String containerLocation) {
+        ZarrV3KeyValueReader reader = new ZarrV3KeyValueReader(access, containerLocation, getGsonBuilder(), getCacheAttributes());
+        reader.setDimensionSeparator(getDimensionSeparator());
+        return reader;
+    }
+
+}

--- a/src/main/java/org/janelia/saalfeldlab/n5/universe/options/ZarrBuilder.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/universe/options/ZarrBuilder.java
@@ -1,0 +1,18 @@
+package org.janelia.saalfeldlab.n5.universe.options;
+
+public abstract class ZarrBuilder extends AbstractN5Builder {
+
+    protected String dimensionSeparator;
+
+    ZarrBuilder(AbstractN5Builder sharedOptions, String dimensionSeparator) {
+        super(sharedOptions);
+        this.dimensionSeparator = dimensionSeparator;
+    }
+
+    public String getDimensionSeparator() {
+        return dimensionSeparator;
+    }
+
+    public abstract ZarrBuilder dimensionSeparator(String dimensionSeparator);
+
+}

--- a/src/test/java/org/janelia/saalfeldlab/n5/universe/options/N5FactoryOptionsTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/universe/options/N5FactoryOptionsTest.java
@@ -1,0 +1,96 @@
+package org.janelia.saalfeldlab.n5.universe.options;
+
+import com.google.gson.GsonBuilder;
+import org.jspecify.annotations.NonNull;
+import org.junit.Test;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertTrue;
+
+public class N5FactoryOptionsTest {
+
+    private static AbstractN5Builder @NonNull [] getBuilders(N5FactoryOptions options) {
+        return new AbstractN5Builder[]{options.getN5Builder(), options.getHdf5Builder(), options.getZarr2Builder(), options.getZarr3Builder()};
+    }
+
+    @Test
+    public void defaults() {
+        final N5FactoryOptions options = new N5FactoryOptions();
+
+        AbstractN5Builder[] builders = getBuilders(options);
+        for (AbstractN5Builder builder : builders) {
+            assertTrue(builder.getCacheAttributes());
+            assertNotNull(builder.getGsonBuilder());
+        }
+
+        assertEquals(".", options.getZarr2Builder().getDimensionSeparator());
+        assertEquals("/", options.getZarr3Builder().getDimensionSeparator());
+
+        assertTrue(options.getZarr2Builder().getMapN5DatasetAttributes());
+        assertTrue(options.getZarr2Builder().getMergeAttributes());
+
+        assertArrayEquals(new int[]{64, 64, 64, 1, 1}, options.getHdf5Builder().getDefaultBlockSize());
+        assertFalse(options.getHdf5Builder().getOverrideBlockSize());
+    }
+
+
+    @Test
+    public void sharedOptionsPropagate() {
+        final N5FactoryOptions options = new N5FactoryOptions();
+        AbstractN5Builder[] builders = getBuilders(options);
+
+        GsonBuilder initFromBuilder = options.getN5Builder().getGsonBuilder();
+
+        for (AbstractN5Builder builder : builders) {
+            assertTrue(builder.getCacheAttributes());
+            assertSame(initFromBuilder, builder.getGsonBuilder());
+        }
+
+        options.cacheAttributes(false);
+        GsonBuilder shared = new GsonBuilder();
+        options.gsonBuilder(shared);
+
+        for (AbstractN5Builder builder : builders) {
+            assertFalse(builder.getCacheAttributes());
+            assertSame(shared, builder.getGsonBuilder());
+        }
+    }
+
+    @Test
+    public void perFormatOverrides() {
+        GsonBuilder shared = new GsonBuilder();
+        final N5FactoryOptions options = new N5FactoryOptions()
+                .cacheAttributes(true)
+                .gsonBuilder(shared);
+
+        options.getZarr2Builder().cacheAttributes(false);
+
+        assertFalse(options.getZarr2Builder().getCacheAttributes());
+        assertTrue(options.getN5Builder().getCacheAttributes());
+        assertTrue(options.getHdf5Builder().getCacheAttributes());
+        assertTrue(options.getZarr3Builder().getCacheAttributes());
+
+        final GsonBuilder perFormat = new GsonBuilder();
+        options.zarr3(opts -> opts.gsonBuilder(perFormat));
+
+        assertSame(perFormat, options.getZarr3Builder().getGsonBuilder());
+        assertSame(shared, options.getN5Builder().getGsonBuilder());
+        assertSame(shared, options.getHdf5Builder().getGsonBuilder());
+        assertSame(shared, options.getZarr2Builder().getGsonBuilder());
+    }
+
+    @Test
+    public void consumerStyleConfigUsesSameBuilderInstance() {
+        final N5FactoryOptions options = new N5FactoryOptions();
+        final HDF5Builder[] seen = new HDF5Builder[1];
+
+        final N5FactoryOptions returned = options.hdf5(builder -> seen[0] = builder);
+
+        assertSame(options, returned);
+        assertSame(options.getHdf5Builder(), seen[0]);
+    }
+}

--- a/src/test/java/org/janelia/saalfeldlab/n5/universe/storage/zarr/ZarrStorageTests.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/universe/storage/zarr/ZarrStorageTests.java
@@ -65,9 +65,11 @@ public class ZarrStorageTests {
 
 		@Override protected N5Writer createTempN5Writer(String location, GsonBuilder gsonBuilder, String dimensionSeparator, boolean mapN5DatasetAttributes) {
 
-			factory.gsonBuilder(gsonBuilder);
-			factory.zarrDimensionSeparator(dimensionSeparator);
-			factory.zarrMapN5Attributes(mapN5DatasetAttributes);
+			factory.getOptions().gsonBuilder(gsonBuilder)
+                    .zarr2(opts -> opts
+                            .dimensionSeparator(dimensionSeparator)
+                            .mapN5DatasetAttributes(mapN5DatasetAttributes)
+                    );
 			final N5Writer writer = getWriter(location);
 			tempWriters.add(writer);
 			return writer;
@@ -75,13 +77,13 @@ public class ZarrStorageTests {
 
 		@Override protected N5Reader createN5Reader(String location, GsonBuilder gson) {
 
-			factory.gsonBuilder(gson);
+			factory.getOptions().gsonBuilder(gson);
 			return getReader(location);
 		}
 
 		@Override protected N5Writer createN5Writer(String location, GsonBuilder gson) {
 
-			factory.gsonBuilder(gson);
+			factory.getOptions().gsonBuilder(gson);
 			return getWriter(location);
 		}
 
@@ -135,9 +137,11 @@ public class ZarrStorageTests {
 
 		@Override protected N5Writer createTempN5Writer(String location, GsonBuilder gsonBuilder, String dimensionSeparator, boolean mapN5DatasetAttributes) {
 
-			factory.gsonBuilder(gsonBuilder);
-			factory.zarrDimensionSeparator(dimensionSeparator);
-			factory.zarrMapN5Attributes(mapN5DatasetAttributes);
+            factory.getOptions().gsonBuilder(gsonBuilder)
+                    .zarr2(opts -> opts
+                            .dimensionSeparator(dimensionSeparator)
+                            .mapN5DatasetAttributes(mapN5DatasetAttributes)
+                    );
 			final N5Writer writer = getWriter(location);
 			tempWriters.add(writer);
 			return writer;
@@ -145,13 +149,13 @@ public class ZarrStorageTests {
 
 		@Override protected N5Reader createN5Reader(String location, GsonBuilder gson) {
 
-			factory.gsonBuilder(gson);
+			factory.getOptions().gsonBuilder(gson);
 			return getReader(location);
 		}
 
 		@Override protected N5Writer createN5Writer(String location, GsonBuilder gson) {
 
-			factory.gsonBuilder(gson);
+			factory.getOptions().gsonBuilder(gson);
 			return getWriter(location);
 		}
 

--- a/src/test/java/org/janelia/saalfeldlab/n5/universe/storage/zarr/zarr3/Zarr3HttpFactoryTest.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/universe/storage/zarr/zarr3/Zarr3HttpFactoryTest.java
@@ -99,7 +99,9 @@ public class Zarr3HttpFactoryTest extends ZarrStorageTests.Zarr3FactoryTest {
 	@Override public N5Factory getFactory() {
 
 		if (factory == null) {
-			factory = new N5Factory().cacheAttributes(false);
+			N5Factory n5Factory = new N5Factory();
+			n5Factory.getOptions().cacheAttributes(false);
+			factory = n5Factory;
 		}
 		return factory;
 	}


### PR DESCRIPTION
This introduces `N5FactoryOptions` and the associated per-format `Builder`s for configuring the behavior of `N5Factory`, particularly allowing per-format configuration options.

Format-specific option configuration methods in `N5Factory` are deprecated .
