### PR TITLE
Commons io test scope

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -219,12 +219,6 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>commons-io</groupId>
-			<artifactId>commons-io</artifactId>
-			<version>${commons-io.version}</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
 			<groupId>io.findify</groupId>
 			<artifactId>s3mock_2.12</artifactId>
 			<version>${s3mock_2.12.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,7 @@
 		<n5-google-cloud.version>6.0.0</n5-google-cloud.version>
 		<n5-hdf5.version>3.0.0</n5-hdf5.version>
 		<n5-imglib2.version>8.0.0</n5-imglib2.version>
-		<n5-zarr.version>2.0.0</n5-zarr.version>
+		<n5-zarr.version>2.0.1</n5-zarr.version>
 		<n5-zstandard.version>2.0.0</n5-zstandard.version>
 
 		<jackson-jq.version>1.0.0-preview.20191208</jackson-jq.version>


### PR DESCRIPTION
- remove explicit test scoped `commons-io` since it is already provided transitively, and otherwise causes some conflicts during certain test run configurations
- bump n5-zarr 2.0.0 -> 2.0.1