### PR TITLE
Cached factory thread safety

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,13 +5,13 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>44.0.0</version>
+		<version>45.0.0</version>
 		<relativePath />
 	</parent>
 
 	<groupId>org.janelia.saalfeldlab</groupId>
 	<artifactId>n5-universe</artifactId>
-	<version>3.0.3-SNAPSHOT</version>
+	<version>3.1.0-SNAPSHOT</version>
 
 	<name>N5-Universe</name>
 	<description>Utilities spanning all of the N5 repositories</description>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.scijava</groupId>
 		<artifactId>pom-scijava</artifactId>
-		<version>45.0.0</version>
+		<version>44.0.0</version>
 		<relativePath />
 	</parent>
 

--- a/src/main/java/org/janelia/saalfeldlab/n5/universe/N5Factory.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/universe/N5Factory.java
@@ -34,6 +34,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
+import java.util.function.Supplier;
 import java.util.regex.Pattern;
 
 import static org.janelia.saalfeldlab.n5.universe.StorageFormat.*;
@@ -688,6 +689,52 @@ public class N5Factory implements Serializable {
             }
 		}
 		return null;
+	}
+
+	/**
+	 * Get a new {@link N5Writer} IFF the container already exists. If one does not already exist,
+	 * a new one will NOT be created.
+	 * This is achieved by first opening a reader at the location, and only then opening
+	 * a writer if the reader successfully opens.
+	 *
+	 * @param storage the storage format, or null
+	 * @param access to the key-value backend
+	 * @param location root URI of the container
+	 * @return a writer for the existing container
+	 */
+	public N5Writer openExistingWriter(@Nullable final StorageFormat storage, final KeyValueAccess access, final URI location) {
+
+		requireContainerExists(() -> openReader(storage, access, location));
+		return openWriter(storage, access, location);
+	}
+
+	/**
+	 * Get a new {@link N5Writer} IFF the container already exists. If one does not already exist,
+	 * a new one will NOT be created.
+	 * This is achieved by first opening a reader at the location, and only then opening
+	 * a writer if the reader successfully opens.
+	 *
+	 * @param uri the container location, optionally prefixed with a storage format
+	 * @return a writer for the existing container
+	 */
+	public N5Writer openExistingWriter(final String uri) {
+
+		requireContainerExists(() -> openReader(uri));
+		return openWriter(uri);
+	}
+
+    /**
+	 * Test if a reader can be opened from given supplier
+	 *
+	 * @throws N5IOException if the container does not exist
+     */
+	protected void requireContainerExists(Supplier<N5Reader> getReader) throws N5IOException {
+		//noinspection EmptyTryBlock
+		try (N5Reader ignored = getReader.get()) {
+			/* Just want to verify we can open, then we close to get the writer*/
+		} catch (final Exception e) {
+			throw new N5IOException("Existing container could not be opened, or does not exist.", e);
+		}
 	}
 
     /**

--- a/src/main/java/org/janelia/saalfeldlab/n5/universe/N5Factory.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/universe/N5Factory.java
@@ -701,8 +701,10 @@ public class N5Factory implements Serializable {
 	 * @param access to the key-value backend
 	 * @param location root URI of the container
 	 * @return a writer for the existing container
+	 *
+	 * @throws N5IOException if the container does not exist, no attempt will be made to create it
 	 */
-	public N5Writer openExistingWriter(@Nullable final StorageFormat storage, final KeyValueAccess access, final URI location) {
+	public N5Writer openExistingWriter(@Nullable final StorageFormat storage, final KeyValueAccess access, final URI location) throws N5IOException {
 
 		requireContainerExists(() -> openReader(storage, access, location));
 		return openWriter(storage, access, location);
@@ -716,8 +718,10 @@ public class N5Factory implements Serializable {
 	 *
 	 * @param uri the container location, optionally prefixed with a storage format
 	 * @return a writer for the existing container
+	 *
+	 * @throws N5IOException if the container does not exist, no attempt will be made to create it
 	 */
-	public N5Writer openExistingWriter(final String uri) {
+	public N5Writer openExistingWriter(final String uri) throws N5IOException {
 
 		requireContainerExists(() -> openReader(uri));
 		return openWriter(uri);

--- a/src/main/java/org/janelia/saalfeldlab/n5/universe/N5FactoryWithCache.java
+++ b/src/main/java/org/janelia/saalfeldlab/n5/universe/N5FactoryWithCache.java
@@ -6,62 +6,152 @@ import org.janelia.saalfeldlab.n5.*;
 import org.janelia.saalfeldlab.n5.hdf5.N5HDF5Reader;
 import org.janelia.saalfeldlab.n5.zarr.ZarrKeyValueReader;
 import org.janelia.saalfeldlab.n5.zarr.v3.ZarrV3KeyValueReader;
-import org.jspecify.annotations.Nullable;
 
 import java.net.URI;
 import java.nio.file.Paths;
-import java.util.HashMap;
 import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.Supplier;
 
+/**
+ * An {@link N5Factory} that caches opened readers and writers by normalized URI.
+ * <p>
+ * `openReader`/`openWriter` calls on cached containers is non-blocking and thread-safe.
+ * If the container is not cached yet, the open call syncronizes on `this` instance to ensure
+ * thread safe.
+ */
 public class N5FactoryWithCache extends N5Factory {
 
-	private final HashMap<URI, N5Reader> readerCache = new HashMap<>();
-	private final HashMap<URI, N5Writer> writerCache = new HashMap<>();
+	private final ConcurrentHashMap<URI, N5Reader> readerCache = new ConcurrentHashMap<>();
+	private final ConcurrentHashMap<URI, N5Writer> writerCache = new ConcurrentHashMap<>();
+
+	/**
+	 * Open a reader for the container. If a cached reader is present, return it.
+	 * If no cached reader, but a cached writer, return it as an N5Reader.
+	 * Finally, open a new reader if not present in the cache.
+	 */
+	public N5Reader openReaderAllowCachedWriter(StorageFormat storage, KeyValueAccess access, URI location) {
+
+		N5Reader cachedReader = getCachedReaderAllowWriter(storage, location);
+		if (cachedReader != null)
+			return cachedReader;
+
+		return cachedOpenReader(storage, access, location);
+	}
+
+	/**
+	 * Open a reader for the container. If a cached reader is present, return it.
+	 * If no cached reader, but a cached writer, return it as an N5Reader.
+	 * Finally, open a new reader if not present in the cache.
+	 */
+	public N5Reader openReaderAllowCachedWriter(String uri) {
+
+		final Pair<StorageFormat, URI> parsed = StorageFormat.parseUri(uri);
+		final StorageFormat storage = parsed.getA();
+		final URI location = parsed.getB();
+
+		N5Reader cachedReader = getCachedReaderAllowWriter(storage, location);
+		if (cachedReader != null)
+			return cachedReader;
+
+		return openReader(uri);
+	}
+
+	private N5Reader getCachedReaderAllowWriter(StorageFormat storage, URI location) {
+		/* try to get a cached reader*/
+		final N5Reader readerFromCache = getReaderFromCache(storage, location);
+		if (readerFromCache != null)
+			return readerFromCache;
+
+		/* else see if we have a cached writer we can return as an N5Reader*/
+		final boolean dontTestWrite = false;
+        return getWriterFromCache(storage, location, dontTestWrite);
+    }
+
+	private N5Reader cachedOpenReader(StorageFormat storage, KeyValueAccess access, URI location) {
+
+		/* if possible, return cached reader without synchronizing */
+		final N5Reader cached = getReaderFromCache(storage, location);
+		if (cached != null)
+			return cached;
+
+		synchronized (this) {
+
+			/* another thread may have opened it while we waited */
+			final N5Reader reopened = getReaderFromCache(storage, location);
+			if (reopened != null)
+				return reopened;
+
+			final N5Reader reader = super.openReader(storage, access, location);
+			if (reader != null)
+				readerCache.put(normalizeUri(location), reader);
+			return reader;
+		}
+	}
 
 	@Override
 	public N5Reader openReader(StorageFormat storage, KeyValueAccess access, URI location) {
 
-		final N5Reader reader = getReaderFromCache(storage, location);
-		if (reader != null)
-			return reader;
-		return openAndCacheReader(storage, access, location);
+		return cachedOpenReader(storage, access, location);
 	}
 
-	private N5Reader openAndCacheReader(StorageFormat storageFormat, KeyValueAccess access, URI uri) {
-
-		final N5Reader reader = super.openReader(storageFormat, access, uri);
-		if (reader == null)
-			return null;
-
-		URI normalUri = normalizeUri(uri);
-		readerCache.put(normalUri, reader);
-		return reader;
-	}
-
-	protected synchronized N5Reader getReaderFromCache(StorageFormat format, URI location) {
+	protected N5Reader getReaderFromCache(StorageFormat format, URI location) {
 
 		final URI uri = normalizeUri(location);
 		final N5Reader reader = readerCache.get(uri);
 		if (reader == null)
 			return null;
 
-		if (!n5MatchesFormat(reader, format) || !canRead(reader)) {
-			readerCache.remove(uri);
+		boolean readerIsValid = n5MatchesFormat(reader, format) && canRead(reader);
+		if (!readerIsValid) {
+			readerCache.remove(uri, reader);
 			return null;
 		}
-
 		return reader;
 	}
 
 	@Override
 	public N5Writer openWriter(StorageFormat storage, KeyValueAccess access, URI location) {
 
-		final N5Writer writer = getWriterFromCache(storage, location);
-		if (writer != null)
+		final boolean testWrite = true;
+		final N5Writer cached = getWriterFromCache(storage, location, testWrite);
+		if (cached != null)
+			return cached;
+
+        synchronized (this) {
+			/* see if someone opened this while we were waiting. */
+			final N5Writer reopened = getWriterFromCache(storage, location, testWrite);
+			if (reopened != null)
+				return reopened;
+
+			final N5Writer writer = super.openWriter(storage, access, location);
+			if (writer != null)
+				writerCache.put(normalizeUri(location), writer);
 			return writer;
-		return openAndCacheWriter(storage, access, location);
+		}
 	}
 
+	protected N5Writer getWriterFromCache(StorageFormat format, URI location, boolean testWrite) {
+
+		final URI uri = normalizeUri(location);
+		final N5Writer writer = writerCache.get(uri);
+		if (writer == null)
+			return null;
+
+		boolean writerIsValid = n5MatchesFormat(writer, format) && (!testWrite || canWrite(writer));
+
+		if (!writerIsValid) {
+			writerCache.remove(uri, writer);
+			return null;
+		}
+		return writer;
+	}
+
+	/**
+	 * Test if a read attempt on this {@link N5Reader} will succeed.
+	 *
+     * @return if read was successful
+     */
 	private boolean canRead(N5Reader reader) {
 
 		try {
@@ -76,53 +166,53 @@ public class N5FactoryWithCache extends N5Factory {
 		}
 	}
 
-	private N5Writer openAndCacheWriter(StorageFormat storageFormat, KeyValueAccess access, URI uri) {
-
-		final N5Writer writer = super.openWriter(storageFormat, access, uri);
-		if (writer == null)
-			return null;
-
-		URI normalUri = normalizeUri(uri);
-		writerCache.put(normalUri, writer);
-		return writer;
-	}
-
-	protected synchronized N5Writer getWriterFromCache(StorageFormat format, URI uri) {
-
-		URI normalUri = normalizeUri(uri);
-		final N5Writer writer = writerCache.get(normalUri);
-		if (writer == null)
-			return null;
-
-		if (!n5MatchesFormat(writer, format) || !canWrite(writer)) {
-			writerCache.remove(normalUri);
-			return null;
-		}
-
-		return writer;
-	}
+	/**
+	 * Test if a write attempt on this {@link N5Writer} will succeed.
+	 * Writes a dummy placeholder metadata key/value that is immediately removed if successful.
+	 *
+	 * @return if write was successful
+	 */
 
 	private boolean canWrite(N5Writer writer) {
 
+		/* If we already have a writer, and we `canRead`, it means we passed the `canWrite` check the first time.
+		* In this case, that's enough evidence that we `canWrite`. It doesn't guarantee, e.g someone didn't change
+		* permissions underneath us, but we never guarded against that anyway. */
 		if (canRead(writer))
 			return true;
 
-		final String uuid = UUID.randomUUID().toString();
-		try {
-
-
-			/* Not ideal, but we want to guarantee that the writer is write-able.
-			 * Normally this is guaranteed at construction, but it isn't being constructed here. */
-			writer.setAttribute("/", uuid, "CACHE_CHECK");
-			return true;
-		} catch (Exception e) {
-			return false;
-		} finally {
+		synchronized (this) {
+			final String uuid = UUID.randomUUID().toString();
 			try {
-				/* If it fails, defer to the result of the outer try/catch*/
-				writer.removeAttribute("/", uuid);
-			} catch (Exception ignored) {
+				/* Not ideal, but we want to guarantee that the writer is write-able.
+				 * Normally this is guaranteed at construction, but it isn't being constructed here. */
+				writer.setAttribute("/", uuid, "CACHE_CHECK");
+				return true;
+			} catch (Exception e) {
+				return false;
+			} finally {
+				try {
+					/* If it fails, defer to the result of the outer try/catch*/
+					writer.removeAttribute("/", uuid);
+				} catch (Exception ignored) {
+				}
 			}
+		}
+	}
+
+	@Override
+	protected void requireContainerExists(Supplier<N5Reader> getReader) throws N5Exception.N5IOException {
+		N5Reader reader = null;
+		try {
+			reader = getReader.get();
+		} catch (final Exception e) {
+			throw new N5Exception.N5IOException("Existing container could not be opened, or does not exist.", e);
+		} finally {
+			/* For the N5FactoryWithCache, we don't want to close the reader necessarily, since w
+			* we may have it cached for later re-use. However, for HDF5 specifically, we must close it
+			* since it is not valid to have a reader and writer open at the same time. */
+			if (reader instanceof N5HDF5Reader)
+				reader.close();
 		}
 	}
 

--- a/src/test/java/org/janelia/saalfeldlab/n5/universe/N5FactoryTests.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/universe/N5FactoryTests.java
@@ -14,7 +14,6 @@ import org.janelia.saalfeldlab.n5.zarr.ZarrKeyValueWriter;
 import org.janelia.saalfeldlab.n5.zarr.v3.ZarrV3KeyValueReader;
 import org.janelia.saalfeldlab.n5.zarr.v3.ZarrV3KeyValueWriter;
 import org.junit.Test;
-import org.junit.runners.Parameterized;
 
 import java.io.File;
 import java.io.IOException;
@@ -22,7 +21,6 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -32,15 +30,17 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 public class N5FactoryTests {
 
-	private StorageFormat[] reorderPreferedStorageFormat(StorageFormat preferredStorageFormat) {
+	protected N5Factory newN5Factory() {
+		return new N5Factory();
+	};
+
+	protected StorageFormat[] reorderPreferedStorageFormat(StorageFormat preferredStorageFormat) {
 
 		final StorageFormat[] defaultOrder = StorageFormat.values();
 		final List<StorageFormat> reorder = new ArrayList<>(Arrays.asList(defaultOrder));
@@ -52,7 +52,7 @@ public class N5FactoryTests {
 	@Test
 	public void testStorageFormatOrderWithPreference() {
 
-		N5Factory factory = new N5Factory();
+		N5Factory factory = newN5Factory();
 		final StorageFormat[] defaultPriority = StorageFormat.values();
 		assertArrayEquals(defaultPriority, factory.orderedStorageFormats());
 
@@ -119,7 +119,7 @@ public class N5FactoryTests {
 	@Test
 	public void testWriterTypeByExtension() throws IOException {
 
-		final N5Factory factory = new N5Factory();
+		final N5Factory factory = newN5Factory();
 
 		File tmp = null;
 		try {
@@ -153,7 +153,7 @@ public class N5FactoryTests {
 	@Test
 	public void testWriterTypeByPrefix() throws IOException {
 
-		final N5Factory factory = new N5Factory();
+		final N5Factory factory = newN5Factory();
 
 		File tmp = null;
 		try {
@@ -190,7 +190,7 @@ public class N5FactoryTests {
 
 	@Test
 	public void testDefaultForAmbiguousWritersWithPreference() throws IOException {
-		final N5Factory factory = new N5Factory();
+		final N5Factory factory = newN5Factory();
 		factory.preferredStorageFormat(StorageFormat.N5);
 
 		File tmp = null;
@@ -232,7 +232,7 @@ public class N5FactoryTests {
 	@Test
 	public void testDefaultForAmbiguousWriters() throws IOException {
 
-		final N5Factory factory = new N5Factory();
+		final N5Factory factory = newN5Factory();
 
 		File tmp = null;
 		try {
@@ -287,7 +287,7 @@ public class N5FactoryTests {
 	@Test
 	public void testAmbiguousZarrFormat() throws IOException {
 
-		final N5Factory factory = new N5Factory();
+		final N5Factory factory = newN5Factory();
 		File tmpDir = Files.createTempDirectory("factory-test-").toFile();
 
 		/* by default, should be zarr 3 with no other information */
@@ -323,7 +323,7 @@ public class N5FactoryTests {
 	@Test
 	public void testForExistingWriters() throws IOException {
 
-		final N5Factory factory = new N5Factory();
+		final N5Factory factory = newN5Factory();
 
 		File tmp = null;
 		try {
@@ -356,7 +356,7 @@ public class N5FactoryTests {
 	@Test
 	public void testDefaultForAmbiguousReaders() throws IOException {
 
-		final N5Factory factory = new N5Factory();
+		final N5Factory factory = newN5Factory();
 		final ArrayList<N5Writer> writers = new ArrayList<>();
 		File tmp = null;
 		try {
@@ -409,130 +409,6 @@ public class N5FactoryTests {
 				} catch (Exception e) {
 				}
 			}
-		} finally {
-			FileUtils.deleteDirectory(tmp);
-		}
-	}
-
-	@Test
-	public void testCachedFactoryKeys() throws IOException {
-
-		final N5FactoryWithCache cachedFactory = new N5FactoryWithCache();
-
-		File tmp = null;
-		try {
-			tmp = Files.createTempDirectory("n5-cachedFactory-test-").toFile();
-			final String tmpPath = tmp.getAbsolutePath();
-
-			/* Writers */
-			final N5Writer writer1 = cachedFactory.openWriter(tmpPath); // a ZarrKeyValueWriter
-			final N5Writer writer2 = cachedFactory.openWriter(tmpPath);
-			assertSame(writer2, writer1);
-
-			final N5Writer writerFromStoragePrefix = cachedFactory.openWriter("zarr3:" + tmpPath);
-			assertSame(writerFromStoragePrefix, writer1);
-
-			final N5Writer writerFromStoragePrefix2 = cachedFactory.openWriter("zarr3://" + tmpPath);
-			assertSame(writerFromStoragePrefix2, writer1);
-
-			final N5Writer writerDifferentStorageFormat = cachedFactory.openWriter(StorageFormat.N5, tmpPath);
-			assertNotSame(writerDifferentStorageFormat, writer1);
-
-			final N5Writer writerFromStorageType = cachedFactory.openWriter(StorageFormat.ZARR3, tmpPath);
-			assertNotSame(writerFromStorageType, writerDifferentStorageFormat);
-			assertNotSame(writerFromStorageType, writer1);
-
-
-			/* Readers */
-			final N5Reader reader1 = cachedFactory.openReader(tmpPath);
-			assertNotSame(reader1, writer1);
-
-			final N5Reader reader2 = cachedFactory.openReader(tmpPath);
-			assertSame(reader2, reader1);
-
-			final N5Reader readerFromStoragePrefix = cachedFactory.openReader("zarr3:" + tmpPath);
-			assertSame(readerFromStoragePrefix, reader1);
-
-			final N5Reader readerFromStoragePrefix2 = cachedFactory.openReader("zarr3://" + tmpPath);
-			assertSame(readerFromStoragePrefix2, reader1);
-
-			final N5Reader readerDifferentStorageFormat = cachedFactory.openReader(StorageFormat.N5, tmpPath);
-			assertNotSame(readerDifferentStorageFormat, reader1);
-
-			final N5Reader readerFromStorageType = cachedFactory.openReader(StorageFormat.ZARR3, tmpPath);
-			assertNotSame(readerFromStorageType, readerDifferentStorageFormat);
-			assertNotSame(readerFromStorageType, reader1);
-
-
-			/* path normalization */
-			N5Reader expected = readerFromStorageType;
-
-			final N5Reader readerFromUri = cachedFactory.openReader(tmp.toURI().toString());
-			assertSame(readerFromUri, expected);
-
-			final N5Reader readerSlash = cachedFactory.openReader(tmpPath + "/");
-			assertSame(readerSlash, expected);
-
-			final N5Reader readerNotNormal = cachedFactory.openReader(tmpPath + "/foo/..");
-			assertSame(readerNotNormal, expected);
-
-			/* different methods of URI creation */
-			final N5Reader readerFromFileUri = cachedFactory.openReader(tmp.toURI().toString());
-			assertSame(readerFromFileUri, expected);
-
-			final N5Reader readerFromPathUri = cachedFactory.openReader(tmp.toPath().toUri().toString());
-			assertSame(readerFromPathUri, expected);
-
-
-			/* relative paths */
-			final String rootName = "monkeySee.n5";
-			final String absPath = Paths.get(rootName).toFile().getAbsolutePath();
-
-			final N5Writer writerAbs = cachedFactory.openWriter(absPath);
-			final N5Writer writerRel = cachedFactory.openWriter("./" + rootName);
-			assertSame(String.format("writers not same instance: %s \n%s\n", writerRel.getURI(), writerAbs.getURI()),
-					writerRel, writerAbs);
-
-			final N5Writer writerRel2 = cachedFactory.openWriter(rootName);
-			assertSame(String.format("writers not same instance: %s \n%s\n", writerRel2.getURI(), writerAbs.getURI()),
-					writerRel2, writerAbs);
-
-			final N5Writer writerRel3 = cachedFactory.openWriter(rootName + "/foo/..");
-			assertSame(String.format("writers not same instance: %s \n%s\n", writerRel3.getURI(), writerAbs.getURI()),
-					writerRel3, writerAbs);
-
-			/*Clean up*/
-			writerAbs.remove();
-
-
-			/* clear and remove */
-			cachedFactory.clear();
-
-			final N5Reader readerAfterClear = cachedFactory.openReader(tmpPath);
-			assertNotSame(readerAfterClear, expected);
-			expected = readerAfterClear;
-
-			final N5Writer writerAfterClear = cachedFactory.openWriter(tmpPath);
-			assertNotSame(writerAfterClear, expected);
-
-			// remove
-			cachedFactory.remove(tmpPath);
-			final N5Reader readerAfterRemove = cachedFactory.openReader(tmpPath);
-			assertNotSame(readerAfterRemove, expected);
-			expected = readerAfterRemove;
-
-			final N5Writer writerAfterRemove = cachedFactory.openWriter(tmpPath);
-			assertNotSame(writerAfterRemove, writerAfterClear);
-
-			// remove normalization
-			cachedFactory.remove("zarr:" + tmpPath);
-			final N5Reader readerAfterRemovePrefix = cachedFactory.openReader(tmpPath);
-			assertNotSame(readerAfterRemovePrefix, expected);
-
-			final N5Writer writerAfterRemovePrefix = cachedFactory.openWriter(tmpPath);
-			assertNotSame(writerAfterRemovePrefix, writerAfterRemove);
-
-
 		} finally {
 			FileUtils.deleteDirectory(tmp);
 		}

--- a/src/test/java/org/janelia/saalfeldlab/n5/universe/N5FactoryTests.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/universe/N5FactoryTests.java
@@ -29,12 +29,14 @@ import java.util.List;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 public class N5FactoryTests {
 
@@ -572,4 +574,28 @@ public class N5FactoryTests {
 			assertEquals(expected.getName() + messageSuffix, expected, n5.getClass());
 		}
 	}
+
+	@Test
+	public void testOpenExistingWriterDoesNotCreate() throws IOException {
+
+		final N5Factory factory = newN5Factory();
+		final File tmp = Files.createTempDirectory( "factory-existing-writer-" ).toFile();
+		try {
+			final File container = new File( tmp, "container.n5" );
+			final String uri = "n5:" + container.getAbsolutePath();
+
+			/* no container yet: it must throw and must not create anything */
+			assertThrows( N5Exception.class, () -> factory.openExistingWriter( uri ) );
+			assertFalse( "openExistingWriter must not create a container", container.exists() );
+
+			/* once the container exists, it opens as a writer */
+			factory.openWriter( uri ).createGroup( "foo" );
+			final N5Writer existing = factory.openExistingWriter( uri );
+			assertNotNull( existing );
+			assertTrue( existing.exists( "foo" ) );
+		} finally {
+			FileUtils.deleteDirectory( tmp );
+		}
+	}
+
 }

--- a/src/test/java/org/janelia/saalfeldlab/n5/universe/N5FactoryWithCacheTests.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/universe/N5FactoryWithCacheTests.java
@@ -82,13 +82,23 @@ public class N5FactoryWithCacheTests extends N5FactoryTests {
 		assertEquals(ZarrKeyValueWriter.class, factory.openWriter(StorageFormat.ZARR, bothZarrs).getClass());
 
 		N5Writer bothZarr3 = factory.openWriter(StorageFormat.ZARR3, bothZarrs);
+
 		/* the base factory re-resolves and returns zarr3 here; the cache instead returns the zarr2 reader cached
 		 * above, since it is still format-compatible with the ambiguous ZARR request */
-		assertEquals(ZarrKeyValueReader.class, factory.openReader(StorageFormat.ZARR, bothZarrs).getClass());
+		N5Reader cachedZarr2Reader = factory.openReader(StorageFormat.ZARR, bothZarrs);
+		assertEquals(ZarrKeyValueReader.class, cachedZarr2Reader.getClass());
+
 		/* the writer cache, on the other hand, was replaced by the zarr3 writer just opened, so ambiguous returns it */
 		assertEquals(ZarrV3KeyValueWriter.class, factory.openWriter(StorageFormat.ZARR, bothZarrs).getClass());
 
-		assertEquals(ZarrKeyValueReader.class, factory.openReader(StorageFormat.ZARR2, bothZarrs).getClass());
+		/* explicitly open a zarr3 reader, which should replace the reader cache entry */
+		assertEquals(ZarrV3KeyValueReader.class, factory.openReader(StorageFormat.ZARR3, bothZarrs).getClass());
+
+		N5Reader newZarr2Reader = factory.openReader(StorageFormat.ZARR2, bothZarrs);
+		assertEquals(ZarrKeyValueReader.class, newZarr2Reader.getClass());
+
+		assertNotSame("returned zarr2 reader should be a new one, since the cache was updated by the previous explicit zarr3 open reader", cachedZarr2Reader, newZarr2Reader);
+		assertSame("returned zarr2 reader should NOW be the same", newZarr2Reader, factory.openReader(StorageFormat.ZARR2, bothZarrs));
 		assertEquals(ZarrKeyValueWriter.class, factory.openWriter(StorageFormat.ZARR2, bothZarrs).getClass());
 	}
 

--- a/src/test/java/org/janelia/saalfeldlab/n5/universe/N5FactoryWithCacheTests.java
+++ b/src/test/java/org/janelia/saalfeldlab/n5/universe/N5FactoryWithCacheTests.java
@@ -1,0 +1,299 @@
+package org.janelia.saalfeldlab.n5.universe;
+
+import org.apache.commons.io.FileUtils;
+import org.janelia.saalfeldlab.n5.N5Reader;
+import org.janelia.saalfeldlab.n5.N5Writer;
+import org.janelia.saalfeldlab.n5.zarr.ZarrKeyValueReader;
+import org.janelia.saalfeldlab.n5.zarr.ZarrKeyValueWriter;
+import org.janelia.saalfeldlab.n5.zarr.v3.ZarrV3KeyValueReader;
+import org.janelia.saalfeldlab.n5.zarr.v3.ZarrV3KeyValueWriter;
+import org.jspecify.annotations.NonNull;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.CyclicBarrier;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+public class N5FactoryWithCacheTests extends N5FactoryTests {
+
+	private @NonNull N5FactoryWithCache newN5FactoryWithCache() {
+		return new N5FactoryWithCache();
+	}
+
+	@Override
+	protected N5Factory newN5Factory() {
+		return newN5FactoryWithCache();
+	}
+
+	/**
+	 * Overrides {@link N5FactoryTests#testAmbiguousZarrFormat} to assert the caching behavior, which differs from the
+	 * base factory in one spot. The cache is keyed by URI and validated for format compatibility: once an ambiguous
+	 * {@code ZARR} open has cached a zarr2 reader, a later ambiguous open at the same URI returns that cached zarr2
+	 * reader even after zarr3 has been added to the container. It does not re-resolve to the preferred zarr3 the way
+	 * the uncached base factory does. Only the marked assertion differs.
+	 */
+	@Override
+	@Test
+	public void testAmbiguousZarrFormat() throws IOException {
+
+		final N5Factory factory = newN5Factory();
+		File tmpDir = Files.createTempDirectory("factory-test-").toFile();
+
+		/* by default, should be zarr 3 with no other information */
+		URI doesntExistsIsZarr3 = tmpDir.toPath().resolve("doesnt_exists_is_zarr3").toUri();
+		N5Writer n5 = factory.openWriter(StorageFormat.ZARR, doesntExistsIsZarr3);
+		assertEquals(ZarrV3KeyValueWriter.class, n5.getClass());
+
+		/* If a zarr2 container exists, it should correctly return zarr2 */
+		URI explicitZarr2 = tmpDir.toPath().resolve("explicit_zarr2").toUri();
+		N5Writer explicitZarr2n5 = factory.openWriter(StorageFormat.ZARR2, explicitZarr2);
+		assertEquals(ZarrKeyValueWriter.class, explicitZarr2n5.getClass());
+
+		N5Reader guessZarr2Reader = factory.openReader(StorageFormat.ZARR, explicitZarr2);
+		assertEquals(ZarrKeyValueReader.class, guessZarr2Reader.getClass());
+
+		N5Reader guessZarr2Writer = factory.openWriter(StorageFormat.ZARR, explicitZarr2);
+		assertEquals(ZarrKeyValueWriter.class, guessZarr2Writer.getClass());
+
+		/* Valid as both zarr2 and zarr3 */
+		URI bothZarrs = tmpDir.toPath().resolve("both_zarr2_zarr3").toUri();
+		N5Writer bothZarr2 = factory.openWriter(StorageFormat.ZARR2, bothZarrs);
+		/* only zarr2 exists so far, so an ambiguous read caches a zarr2 reader here */
+		assertEquals(ZarrKeyValueReader.class, factory.openReader(StorageFormat.ZARR, bothZarrs).getClass());
+		assertEquals(ZarrKeyValueWriter.class, factory.openWriter(StorageFormat.ZARR, bothZarrs).getClass());
+
+		N5Writer bothZarr3 = factory.openWriter(StorageFormat.ZARR3, bothZarrs);
+		/* the base factory re-resolves and returns zarr3 here; the cache instead returns the zarr2 reader cached
+		 * above, since it is still format-compatible with the ambiguous ZARR request */
+		assertEquals(ZarrKeyValueReader.class, factory.openReader(StorageFormat.ZARR, bothZarrs).getClass());
+		/* the writer cache, on the other hand, was replaced by the zarr3 writer just opened, so ambiguous returns it */
+		assertEquals(ZarrV3KeyValueWriter.class, factory.openWriter(StorageFormat.ZARR, bothZarrs).getClass());
+
+		assertEquals(ZarrKeyValueReader.class, factory.openReader(StorageFormat.ZARR2, bothZarrs).getClass());
+		assertEquals(ZarrKeyValueWriter.class, factory.openWriter(StorageFormat.ZARR2, bothZarrs).getClass());
+	}
+
+	@Test
+	public void testCachedFactoryKeys() throws IOException {
+
+		final N5FactoryWithCache cachedFactory = newN5FactoryWithCache();
+
+		File tmp = null;
+		try {
+			tmp = Files.createTempDirectory("n5-cachedFactory-test-").toFile();
+			final String tmpPath = tmp.getAbsolutePath();
+
+			/* Writers */
+			final N5Writer writer1 = cachedFactory.openWriter(tmpPath); // a ZarrKeyValueWriter
+			final N5Writer writer2 = cachedFactory.openWriter(tmpPath);
+			assertSame(writer2, writer1);
+
+			final N5Writer writerFromStoragePrefix = cachedFactory.openWriter("zarr3:" + tmpPath);
+			assertSame(writerFromStoragePrefix, writer1);
+
+			final N5Writer writerFromStoragePrefix2 = cachedFactory.openWriter("zarr3://" + tmpPath);
+			assertSame(writerFromStoragePrefix2, writer1);
+
+			final N5Writer writerDifferentStorageFormat = cachedFactory.openWriter(StorageFormat.N5, tmpPath);
+			assertNotSame(writerDifferentStorageFormat, writer1);
+
+			final N5Writer writerFromStorageType = cachedFactory.openWriter(StorageFormat.ZARR3, tmpPath);
+			assertNotSame(writerFromStorageType, writerDifferentStorageFormat);
+			assertNotSame(writerFromStorageType, writer1);
+
+
+			/* Readers */
+			final N5Reader reader1 = cachedFactory.openReader(tmpPath);
+			assertNotSame(reader1, writer1);
+
+			final N5Reader reader2 = cachedFactory.openReader(tmpPath);
+			assertSame(reader2, reader1);
+
+			final N5Reader readerFromStoragePrefix = cachedFactory.openReader("zarr3:" + tmpPath);
+			assertSame(readerFromStoragePrefix, reader1);
+
+			final N5Reader readerFromStoragePrefix2 = cachedFactory.openReader("zarr3://" + tmpPath);
+			assertSame(readerFromStoragePrefix2, reader1);
+
+			final N5Reader readerDifferentStorageFormat = cachedFactory.openReader(StorageFormat.N5, tmpPath);
+			assertNotSame(readerDifferentStorageFormat, reader1);
+
+			final N5Reader readerFromStorageType = cachedFactory.openReader(StorageFormat.ZARR3, tmpPath);
+			assertNotSame(readerFromStorageType, readerDifferentStorageFormat);
+			assertNotSame(readerFromStorageType, reader1);
+
+
+			/* path normalization */
+			N5Reader expected = readerFromStorageType;
+
+			final N5Reader readerFromUri = cachedFactory.openReader(tmp.toURI().toString());
+			assertSame(readerFromUri, expected);
+
+			final N5Reader readerSlash = cachedFactory.openReader(tmpPath + "/");
+			assertSame(readerSlash, expected);
+
+			final N5Reader readerNotNormal = cachedFactory.openReader(tmpPath + "/foo/..");
+			assertSame(readerNotNormal, expected);
+
+			/* different methods of URI creation */
+			final N5Reader readerFromFileUri = cachedFactory.openReader(tmp.toURI().toString());
+			assertSame(readerFromFileUri, expected);
+
+			final N5Reader readerFromPathUri = cachedFactory.openReader(tmp.toPath().toUri().toString());
+			assertSame(readerFromPathUri, expected);
+
+
+			/* relative paths */
+			final String rootName = "monkeySee.n5";
+			final String absPath = Paths.get(rootName).toFile().getAbsolutePath();
+
+			final N5Writer writerAbs = cachedFactory.openWriter(absPath);
+			final N5Writer writerRel = cachedFactory.openWriter("./" + rootName);
+			assertSame(String.format("writers not same instance: %s \n%s\n", writerRel.getURI(), writerAbs.getURI()),
+					writerRel, writerAbs);
+
+			final N5Writer writerRel2 = cachedFactory.openWriter(rootName);
+			assertSame(String.format("writers not same instance: %s \n%s\n", writerRel2.getURI(), writerAbs.getURI()),
+					writerRel2, writerAbs);
+
+			final N5Writer writerRel3 = cachedFactory.openWriter(rootName + "/foo/..");
+			assertSame(String.format("writers not same instance: %s \n%s\n", writerRel3.getURI(), writerAbs.getURI()),
+					writerRel3, writerAbs);
+
+			/*Clean up*/
+			writerAbs.remove();
+
+
+			/* clear and remove */
+			cachedFactory.clear();
+
+			final N5Reader readerAfterClear = cachedFactory.openReader(tmpPath);
+			assertNotSame(readerAfterClear, expected);
+			expected = readerAfterClear;
+
+			final N5Writer writerAfterClear = cachedFactory.openWriter(tmpPath);
+			assertNotSame(writerAfterClear, expected);
+
+			// remove
+			cachedFactory.remove(tmpPath);
+			final N5Reader readerAfterRemove = cachedFactory.openReader(tmpPath);
+			assertNotSame(readerAfterRemove, expected);
+			expected = readerAfterRemove;
+
+			final N5Writer writerAfterRemove = cachedFactory.openWriter(tmpPath);
+			assertNotSame(writerAfterRemove, writerAfterClear);
+
+			// remove normalization
+			cachedFactory.remove("zarr:" + tmpPath);
+			final N5Reader readerAfterRemovePrefix = cachedFactory.openReader(tmpPath);
+			assertNotSame(readerAfterRemovePrefix, expected);
+
+			final N5Writer writerAfterRemovePrefix = cachedFactory.openWriter(tmpPath);
+			assertNotSame(writerAfterRemovePrefix, writerAfterRemove);
+
+
+		} finally {
+			FileUtils.deleteDirectory(tmp);
+		}
+	}
+
+	/* Many threads opening the same not-yet-cached container must open it exactly once (a single cached instance). */
+	@Test
+	public void testConcurrentOpenIsThreadSafeAndOpensOnce() throws Exception {
+
+		final int threads = 12;
+		final int iterations = 12;
+		final File tmp = Files.createTempDirectory("factory-cache-concurrent-").toFile();
+		try {
+			for (int iteration = 0; iteration < iterations; iteration++) {
+				final N5FactoryWithCache factory = newN5FactoryWithCache();
+				final String uri = tmp.toPath().resolve("iter" + iteration + ".n5").normalize().toUri().toString();
+
+				final Set<N5Writer> writers = runConcurrently(threads, () -> factory.openWriter(uri));
+				assertEquals("iteration " + iteration + ": writer opened more than once", 1, writers.size());
+
+				/* the container now exists; concurrent readers likewise resolve to a single cached reader */
+				final Set<N5Reader> readers = runConcurrently(threads, () -> factory.openReader(uri));
+				assertEquals("iteration " + iteration + ": reader opened more than once", 1, readers.size());
+
+				factory.clear();
+			}
+		} finally {
+			FileUtils.deleteDirectory(tmp);
+		}
+	}
+
+	@Test
+	public void testOpenReaderAllowCachedWriter() throws IOException {
+
+		final File tmp = Files.createTempDirectory( "factory-allow-cached-writer-" ).toFile();
+		try {
+			final String uri = "n5:" + new File( tmp, "container.n5" ).getAbsolutePath();
+			/* create the container on disk so the fresh factories below can open it */
+			new N5FactoryWithCache().openWriter( uri );
+
+			/* 1. a cached reader is returned */
+			final N5FactoryWithCache cachedReaderFactory = newN5FactoryWithCache();
+			final N5Reader cachedReader = cachedReaderFactory.openReader( uri );
+			assertSame( cachedReader, cachedReaderFactory.openReaderAllowCachedWriter( uri ) );
+
+			/* 2. with no cached reader, a cached writer is returned as the reader */
+			final N5FactoryWithCache cachedWriterFactory = newN5FactoryWithCache();
+			final N5Writer cachedWriter = cachedWriterFactory.openWriter( uri );
+			assertSame( cachedWriter, cachedWriterFactory.openReaderAllowCachedWriter( uri ) );
+
+			/* 3. with neither cached, a new reader is opened and cached */
+			final N5FactoryWithCache freshFactory = newN5FactoryWithCache();
+			final N5Reader openedReader = freshFactory.openReaderAllowCachedWriter( uri );
+			assertNotNull( openedReader );
+			assertFalse( "a fresh reader, not a writer-as-reader", openedReader instanceof N5Writer );
+			assertSame( "the opened reader was cached", openedReader, freshFactory.openReader( uri ) );
+		} finally {
+			FileUtils.deleteDirectory( tmp );
+		}
+	}
+
+	/* Run task on every thread simultaneously. */
+	private <T> Set<T> runConcurrently(final int threads, final Callable<T> task) throws Exception {
+
+		final ExecutorService pool = Executors.newFixedThreadPool(threads);
+		try {
+			final CyclicBarrier barrier = new CyclicBarrier(threads);
+			final List<Future<T>> futures = new ArrayList<>();
+			for (int t = 0; t < threads; t++) {
+				futures.add(pool.submit(() -> {
+					barrier.await();
+					return task.call();
+				}));
+			}
+			final Set<T> distinct = Collections.newSetFromMap(new IdentityHashMap<>());
+			for (final Future<T> future : futures) {
+				final T result = future.get(30, TimeUnit.SECONDS);
+				assertNotNull(result);
+				distinct.add(result);
+			}
+			return distinct;
+		} finally {
+			pool.shutdownNow();
+		}
+	}
+}


### PR DESCRIPTION
fix: thread safety of NFactoryWithCache

add api methods:
- openExistingWriter
- openReaderAllowWriter (for N5FactoryWithCache)
- refactor N5FactoryTests to be inheritable